### PR TITLE
Present campaign log in campaign list (incomplete)

### DIFF
--- a/src/_mock/index.js
+++ b/src/_mock/index.js
@@ -1,12 +1,12 @@
-export * from './assets';
-export * from './_mock';
-
-// ----------------------------------------------------------------------
-
 export * from './_job';
+export * from './_mock';
 export * from './_user';
 export * from './_tour';
 export * from './_blog';
+export * from './assets';
+
+// ----------------------------------------------------------------------
+
 export * from './_files';
 export * from './_order';
 export * from './_others';

--- a/src/routes/sections/dashboard.jsx
+++ b/src/routes/sections/dashboard.jsx
@@ -6,10 +6,8 @@ import { AuthGuard, RoleBasedGuard } from 'src/auth/guard';
 
 import { LoadingScreen } from 'src/components/loading-screen';
 
-import { CalendarView } from 'src/sections/calendar/view';
 import { ChatView } from 'src/sections/chat/view';
-
-
+import { CalendarView } from 'src/sections/calendar/view';
 
 // ----------------------------------------------------------------------
 
@@ -362,8 +360,8 @@ export const dashboardRoutes = [
       {
         path: 'chat',
         children: [
-         { 
-          path: '', 
+         {
+          path: '',
           element: <ChatView />,
          },
          {

--- a/src/sections/campaign/discover/admin/creator-stuff/overview.jsx
+++ b/src/sections/campaign/discover/admin/creator-stuff/overview.jsx
@@ -5,14 +5,14 @@ import { PieChart } from '@mui/x-charts';
 import { Box, Card, Grid, Stack, Typography } from '@mui/material';
 
 const OverView = ({ campaign }) => {
-  const generateRandomNumbers = (count) => {
-    const randomNumbers = [];
-    // eslint-disable-next-line no-plusplus
-    for (let i = 0; i < count; i++) {
-      randomNumbers.push(Math.floor(Math.random() * 100)); // generates a random number between 0 and 99
-    }
-    return randomNumbers;
-  };
+  // const generateRandomNumbers = (count) => {
+  //   const randomNumbers = [];
+  //   // eslint-disable-next-line no-plusplus
+  //   for (let i = 0; i < count; i++) {
+  //     randomNumbers.push(Math.floor(Math.random() * 100)); // generates a random number between 0 and 99
+  //   }
+  //   return randomNumbers;
+  // };
 
   const data = [{ label: 'Group A', value: 100 }];
   return (

--- a/src/sections/campaign/discover/admin/view/campaign-manage-creator-view.jsx
+++ b/src/sections/campaign/discover/admin/view/campaign-manage-creator-view.jsx
@@ -40,7 +40,7 @@ const CampaignManageCreatorView = ({ id, campaignId }) => {
   const { data, isLoading } = useGetCreatorById(id);
   const [currentTab, setCurrentTab] = useState('profile');
   const { campaign, campaignLoading } = useGetCampaignById(campaignId);
-  const { data: submissionData, isLoading: submissionLoading } = useGetSubmissions(id, campaignId);
+  const { data: submissionData, /* isLoading: submissionLoading */ } = useGetSubmissions(id, campaignId);
   const theme = useTheme();
   const router = useRouter();
   console.log(submissionData);
@@ -139,19 +139,19 @@ const CampaignManageCreatorView = ({ id, campaignId }) => {
     </Tabs>
   );
 
-  const renderOverview = (
-    <Box display="grid" gridTemplateColumns="repeat(3, 1fr)" gap={2}>
-      <Box
-        sx={{
-          height: 150,
-          p: 3,
-        }}
-        component={Card}
-      >
-        <Typography variant="h3">Draft</Typography>
-      </Box>
-    </Box>
-  );
+  // const renderOverview = (
+  //   <Box display="grid" gridTemplateColumns="repeat(3, 1fr)" gap={2}>
+  //     <Box
+  //       sx={{
+  //         height: 150,
+  //         p: 3,
+  //       }}
+  //       component={Card}
+  //     >
+  //       <Typography variant="h3">Draft</Typography>
+  //     </Box>
+  //   </Box>
+  // );
 
   const renderProfile = (
     <Box display="grid" gridTemplateColumns="repeat(3, 1fr)" gap={2}>

--- a/src/sections/campaign/manage-creator/campaign-detail-item.jsx
+++ b/src/sections/campaign/manage-creator/campaign-detail-item.jsx
@@ -3,8 +3,6 @@ import React, { useState } from 'react';
 
 import { Box, Tab, Tabs, Stack } from '@mui/material';
 
-import { useAuthContext } from 'src/auth/hooks';
-
 import Image from 'src/components/image';
 
 import CampaignInfo from './campaign-info';
@@ -13,7 +11,7 @@ import CampaignMyTasks from './campaign-myTask';
 
 const CampaignDetailItem = ({ campaign }) => {
   const [currentTab, setCurrentTab] = useState('info');
-  const { user } = useAuthContext();
+  // const { user } = useAuthContext();
 
   const renderGallery = (
     <Box

--- a/src/sections/campaign/manage-creator/campaign-myTask.jsx
+++ b/src/sections/campaign/manage-creator/campaign-myTask.jsx
@@ -1,5 +1,4 @@
 import dayjs from 'dayjs';
-import * as Yup from 'yup';
 import { mutate } from 'swr';
 import PropTypes from 'prop-types';
 import { io } from 'socket.io-client';
@@ -16,7 +15,6 @@ import {
 } from '@mui/lab';
 
 import { useGetSubmissions } from 'src/hooks/use-get-submission';
-import useGetFirstDraftBySessionID from 'src/hooks/use-get-first-draft-for-creator';
 
 import { endpoints } from 'src/utils/axios';
 
@@ -37,14 +35,14 @@ const CampaignMyTasks = ({ campaign }) => {
   const { data: submissions } = useGetSubmissions(user.id, campaign?.id);
   console.log(submissions);
 
-  const { data } = useGetFirstDraftBySessionID(campaign.id);
+  // const { data } = useGetFirstDraftBySessionID(campaign.id);
 
-  const isSubmittedFirstDraft = data?.status === 'Submitted';
+  // const isSubmittedFirstDraft = data?.status === 'Submitted';
 
-  const schema = Yup.object().shape({
-    // draft: Yup.string().required(),
-    caption: Yup.string().required(),
-  });
+  // const schema = Yup.object().shape({
+  //   // draft: Yup.string().required(),
+  //   caption: Yup.string().required(),
+  // });
 
   useEffect(() => {
     const socket = io();

--- a/src/sections/campaign/manage/details/view/EditTimeline.jsx
+++ b/src/sections/campaign/manage/details/view/EditTimeline.jsx
@@ -145,13 +145,13 @@ export const EditTimeline = ({ open, campaign, onClose }) => {
     remove(index);
   };
 
-  const handleChange = (e, index) => {
-    setValue(`timeline[${index}].timeline_type`, { name: e.target.value });
-    // eslint-disable-next-line no-unsafe-optional-chaining
-    if (index !== fields?.length - 1) {
-      setValue(`timeline[${index + 1}].dependsOn`, e.target.value);
-    }
-  };
+  // const handleChange = (e, index) => {
+  //   setValue(`timeline[${index}].timeline_type`, { name: e.target.value });
+  //   // eslint-disable-next-line no-unsafe-optional-chaining
+  //   if (index !== fields?.length - 1) {
+  //     setValue(`timeline[${index + 1}].dependsOn`, e.target.value);
+  //   }
+  // };
 
   const closeDialog = () => onClose('timeline');
 

--- a/src/sections/campaign/manage/details/view/campaign-details-manage-view.jsx
+++ b/src/sections/campaign/manage/details/view/campaign-details-manage-view.jsx
@@ -272,15 +272,16 @@ const CampaignDetailManageView = ({ id }) => {
                   ].includes(e)
               )
               .map(
-                (e) =>
+                (e, index) =>
                   campaign?.brand[e] && (
                     <ListItemText
+                      key={index}
                       primary={formatText(e)}
                       secondary={
                         typeof campaign?.brand[e] === 'object' ? (
                           <Stack direction="row" alignItems="center" gap={1} flexWrap="wrap">
-                            {campaign?.brand[e].map((val) => (
-                              <Label>{val}</Label>
+                            {campaign?.brand[e].map((val, index2) => (
+                              <Label key={index2}>{val}</Label>
                             ))}
                           </Stack>
                         ) : (
@@ -351,8 +352,8 @@ const CampaignDetailManageView = ({ id }) => {
         <Stack>
           <Typography variant="subtitle1">Dos</Typography>
           <List>
-            {campaign?.campaignBrief?.campaigns_do.map((elem) => (
-              <ListItem>
+            {campaign?.campaignBrief?.campaigns_do.map((elem, index) => (
+              <ListItem key={index}>
                 <ListItemIcon>
                   <Iconify
                     icon="octicon:dot-24"
@@ -369,8 +370,8 @@ const CampaignDetailManageView = ({ id }) => {
         <Stack mt={2}>
           <Typography variant="subtitle1">Don&apos;ts</Typography>
           <List>
-            {campaign?.campaignBrief?.campaigns_dont.map((elem) => (
-              <ListItem>
+            {campaign?.campaignBrief?.campaigns_dont.map((elem, index) => (
+              <ListItem key={index}>
                 <ListItemIcon>
                   <Iconify
                     icon="octicon:dot-24"
@@ -520,7 +521,7 @@ const CampaignDetailManageView = ({ id }) => {
       <Typography variant="h5">Admin Manager</Typography>
       <List>
         {campaign?.campaignAdmin?.map((item, index) => (
-          <ListItem>
+          <ListItem key={index}>
             <ListItemText primary={`${index + 1}. ${item?.admin?.user?.name}`} />
           </ListItem>
         ))}

--- a/src/sections/campaign/manage/list/CampaignLog.jsx
+++ b/src/sections/campaign/manage/list/CampaignLog.jsx
@@ -1,0 +1,70 @@
+import PropTypes from 'prop-types';
+import { useState, useEffect } from 'react';
+import { enqueueSnackbar } from 'notistack';
+
+import { DataGrid } from '@mui/x-data-grid';
+import { Button, Dialog, DialogTitle, DialogActions } from '@mui/material';
+
+import axiosInstance, { endpoints } from 'src/utils/axios';
+
+import Iconify from 'src/components/iconify';
+
+// https://mui.com/x/react-data-grid/getting-started/
+const rows = [
+  { id: '1', datePerformed: '2024-07-29 06:01:45.925', action: 'Test Action', performedBy: 'Test Admin' },
+];
+
+const cols = [
+  { field: 'datePerformed', headerName: 'Date performed', width: 250 },
+  { field: 'action', headerName: 'Action', width: 250 },
+  { field: 'performedBy', headerName: 'Performed by', width: 150 },
+];
+
+export const CampaignLog = ({ open, campaign, onClose }) => {
+  const [loading, setLoading] = useState(false);
+  const [campaignLog, setCampaignLog] = useState([]);
+
+  useEffect(() => {
+    (async () => {
+      setLoading(true);
+      try {
+        const res = await axiosInstance.get(endpoints.campaign.getCampaignLog(campaign.id));
+        setCampaignLog(res.data);
+      } catch (error) {
+        // TODO TEMP
+        console.log('=== BEGIN CampaignLog useEffect error ===');
+        console.log(error);
+        console.log('=== END CampaignLog useEffect error ===');
+        enqueueSnackbar('Failed to fetch campaign log', { variant: 'error' });
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [campaign.id]);
+
+  return (
+    <Dialog
+      open={open}
+      aria-labelledby='alert-dialog-title'
+      aria-describedby='alert-dialog-description'
+      fullWidth
+      maxWidth='md'
+    >
+      <DialogTitle id="alert-dialog-title">“{campaign.name}” Log</DialogTitle>
+      {loading && <Iconify icon="eos-icons:bubble-loading" />}
+      {/* TODO: Center this */}
+      <div style={{ height: '100vh', width: '95%' }}>
+        <DataGrid rows={rows} columns={cols} />
+      </div>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+CampaignLog.propTypes = {
+  open: PropTypes.bool,
+  campaign: PropTypes.object,
+  onClose: PropTypes.func,
+};

--- a/src/sections/campaign/manage/list/campaign-admin-list.jsx
+++ b/src/sections/campaign/manage/list/campaign-admin-list.jsx
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import React from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { Box, Card, Chip, Stack, Divider, MenuItem, IconButton, Typography } from '@mui/material';
@@ -15,11 +15,16 @@ import Iconify from 'src/components/iconify';
 import { usePopover } from 'src/components/custom-popover';
 import CustomPopover from 'src/components/custom-popover/custom-popover';
 
+import { CampaignLog } from './CampaignLog';
+
 const CampaignList = ({ campaign, onView, onEdit, onDelete }) => {
   const smUp = useResponsive('up', 'sm');
 
   const { user } = useAuthContext();
   const popover = usePopover();
+
+  const [campaignLogIsOpen, setCampaignLogIsOpen] = useState(false);
+  const onCloseCampaignLog = () => setCampaignLogIsOpen(false);
 
   return (
     <>
@@ -153,6 +158,15 @@ const CampaignList = ({ campaign, onView, onEdit, onDelete }) => {
           <Iconify icon="solar:pen-bold" />
           Edit
         </MenuItem> */}
+        <MenuItem
+          onClick={() => {
+            popover.onClose();
+            setCampaignLogIsOpen(true);
+          }}
+        >
+          <Iconify icon="material-symbols:note-rounded" />
+          View Log
+        </MenuItem>
         {user?.role === 'superadmin' && (
           <MenuItem
             onClick={() => {
@@ -166,6 +180,7 @@ const CampaignList = ({ campaign, onView, onEdit, onDelete }) => {
           </MenuItem>
         )}
       </CustomPopover>
+      <CampaignLog open={campaignLogIsOpen} campaign={campaign} onClose={onCloseCampaignLog} />
     </>
   );
 };

--- a/src/sections/campaign/settings/timeline.jsx
+++ b/src/sections/campaign/settings/timeline.jsx
@@ -32,7 +32,7 @@ import TimelineTypeModal from './timeline-type-modal';
 // eslint-disable-next-line react/prop-types
 const Timeline = ({ timelineType, isSmallScreen }) => {
   const { data: timelines, isLoading } = useGetAllTimelineType();
-  const [query, setQuery] = useState('');
+  const [, setQuery] = useState('');
 
   const { data: defaultTimelines, isLoading: defaultTimelineLoading } = useGetDefaultTimeLine();
   const errorTimeline = useBoolean();
@@ -372,7 +372,7 @@ const Timeline = ({ timelineType, isSmallScreen }) => {
                     }
                   />
                 )}
-                {/* 
+                {/*
                   <RHFSelect disabled name={`timeline[${index}].dependsOn`} label="Depends On">
                     {!isLoading &&
                       timelines.map((elem) => (

--- a/src/sections/chat/view/chat-view.jsx
+++ b/src/sections/chat/view/chat-view.jsx
@@ -1,5 +1,3 @@
-import { useEffect} from 'react';
-import PropTypes from 'prop-types';
 import { useParams } from 'react-router-dom';
 
 import Card from '@mui/material/Card';
@@ -7,8 +5,7 @@ import Stack from '@mui/material/Stack';
 import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
 
-import { paths } from 'src/routes/paths';
-import { useRouter, useSearchParams } from 'src/routes/hooks';
+import { useSearchParams } from 'src/routes/hooks';
 
 import { useAuthContext } from 'src/auth/hooks';
 
@@ -25,31 +22,31 @@ import ChatHeaderCompose from '../chat-header-compose';
 
 
 export default function ChatView() {
-  const router = useRouter();
+  // const router = useRouter();
   const { user } = useAuthContext();
   const settings = useSettingsContext();
   const searchParams = useSearchParams();
   const selectedConversationId = searchParams.get('id') || '';
- 
- 
+
+
   const {id} = useParams(); // Extracts the threadId from the route
-  
+
   // useEffect(() => {
   //   if (!selectedConversationId) {
   //     router.push(paths.dashboard.chat);
-  //   } 
+  //   }
   // }, [router, selectedConversationId]);
 
 
   //  const filteredMessages = messages.filter(message => message.threadId === threadId);
 
-  
 
-  // Head is Showing all the search and names 
+
+  // Head is Showing all the search and names
   const renderHead = (
     <Stack direction="row" alignItems="center" flexShrink={0} sx={{ pr: 1, pl: 2.5, py: 1, minHeight: 72 }}>
       {selectedConversationId ? (
-        <ChatHeaderDetail participants={[]} /> 
+        <ChatHeaderDetail participants={[]} />
       ) : (
         <ChatHeaderCompose currentUserId={user.id} />
       )}
@@ -60,10 +57,10 @@ export default function ChatView() {
 
   const renderNav = (
     <ChatNav
-      contacts={[]} 
+      contacts={[]}
       selectedConversationId={selectedConversationId}
     />
-    
+
   );
 
 
@@ -88,9 +85,9 @@ export default function ChatView() {
               borderTop: (theme) => `solid 1px ${theme.palette.divider}`,
             }}
           >
-            
+
              {id? (
-          
+
             <ThreadMessages threadId={id} />
           ) : (
             <Container maxWidth="xl" sx={{justifyContent: 'center', mt:10, alignItems: 'center', height: '100vh'}}>
@@ -99,9 +96,9 @@ export default function ChatView() {
           </Typography>
           </Container>
           )}
-          
-        
-            <ChatRoom  threadId={id}  /> 
+
+
+            <ChatRoom  threadId={id}  />
           </Stack>
         </Stack>
       </Stack>
@@ -111,5 +108,5 @@ export default function ChatView() {
 
 ChatView.propTypes = {
   // id: PropTypes.object.isRequired,
-  // threadId: PropTypes.string, 
+  // threadId: PropTypes.string,
 };

--- a/src/utils/axios.js
+++ b/src/utils/axios.js
@@ -166,6 +166,7 @@ export const endpoints = {
       shortListedCampaign: '/api/campaign/getCampaignsBySessionId',
       getCampaign: (id) => `/api/campaign/getCampaignForCreatorById/${id}`,
     },
+    getCampaignLog: (id) => `/api/campaign/getCampaignLog/${id}`,
   },
   submission: {
     root: '/api/tasks/submissions',


### PR DESCRIPTION
Paths begin with `/src/`.

This feature is not yet complete.
To-do: in `sections/campaign/manage/list/CampaignLog.jsx`, use `campaignLog` to present the campaign log in the `DataGrid`.

Additions:
* `sections/campaign/manage/list/CampaignLog.jsx`. Modal dialog displaying a selected campaign's update log.

`sections/campaign/manage/list/campaign-admin-list.jsx`:
* Added "View Log" menu item

`utils/axios.js`:
* Added `getCampaignLog` endpoint

Resolved warnings in:
* `_mock/index.js`
* `routes/sections/dashboard.jsx`
* `sections/campaign/discover/admin/creator-stuff/overview.jsx`
* `sections/campaign/discover/admin/view/campaign-manage-creator-view.jsx`
* `sections/campaign/manage/details/view/campaign-details-manage-view.jsx`
* `sections/campaign/manage/details/view/EditTimeline.jsx`
* `sections/campaign/manage-creator/campaign-detail-item.jsx`
* `sections/campaign/manage-creator/campaign-myTask.jsx`
* `sections/campaign/settings/timeline.jsx`
* `sections/chat/view/chat-view.jsx`