### PR TITLE
add brand-based sorting and filtering campaign

### DIFF
--- a/src/sections/campaign/discover/admin/campaign-filter.jsx
+++ b/src/sections/campaign/discover/admin/campaign-filter.jsx
@@ -15,13 +15,14 @@ import {
   FormControlLabel,
 } from '@mui/material';
 
+import { createFilterOptions } from '@mui/material/Autocomplete';
 import { useGetCampaignBrandOption } from 'src/hooks/use-get-company-brand';
 
 import Iconify from 'src/components/iconify';
 import Scrollbar from 'src/components/scrollbar';
 
-const CampaignFilter = ({ open, onOpen, onClose, brands, filters, onFilters, reset }) => {
-  const { options } = useGetCampaignBrandOption();
+const CampaignFilter = ({ open, onClose, filters, onFilters, reset }) => {
+  const { data: options, isLoading } = useGetCampaignBrandOption();
 
   const handleFilterStatus = useCallback(
     (e) => {
@@ -31,11 +32,15 @@ const CampaignFilter = ({ open, onOpen, onClose, brands, filters, onFilters, res
   );
 
   const handleFilterBrand = useCallback(
-    (e) => {
-      onFilters('brands', e);
+    (e, newValue) => {
+      onFilters('brands', newValue);
     },
     [onFilters]
   );
+
+  const filterOptions = createFilterOptions({
+    stringify: (option) => option.name,
+  })
 
   const renderHead = (
     <Stack
@@ -75,14 +80,20 @@ const CampaignFilter = ({ open, onOpen, onClose, brands, filters, onFilters, res
 
   const renderBrand = (
     <Stack>
-      <Typography variant="h6">Brand</Typography>
-      {options && (
+      <Typography variant="h6" mb={1.5}>Brand</Typography>
+      {isLoading ? (
+        <Typography>Loading...</Typography>
+      ) : (
+        options && (
         <Autocomplete
           multiple
-          options={options}
-          getOptionLabel={(option) => option?.name}
+          options={options || []}
+          getOptionLabel={(option) => option?.name || ''}
           value={filters.brands}
-          onChange={(event, newValue) => handleFilterBrand(newValue)}
+          onChange={handleFilterBrand}
+          filterOptions={filterOptions}
+          filterSelectedOptions
+          isOptionEqualToValue={(option, value) => option?.id === value?.id}
           renderTags={(value, getTagProps) =>
             value.map((option, index) => {
               const { key, ...tagProps } = getTagProps({ index });
@@ -97,9 +108,18 @@ const CampaignFilter = ({ open, onOpen, onClose, brands, filters, onFilters, res
               );
             })
           }
-          renderInput={(props) => <TextField {...props} label="Brand" />}
+          renderInput={(props) => (
+            <TextField {...props} 
+            label="Search Brands" 
+            onChange={(event) => {
+              const inputValue = event.target.value;
+              filterOptions({ inputValue});
+            }} 
+            />
+         )}
         />
-      )}
+      )
+    )}
     </Stack>
   );
 
@@ -134,9 +154,7 @@ export default CampaignFilter;
 
 CampaignFilter.propTypes = {
   open: PropTypes.bool,
-  onOpen: PropTypes.func,
   onClose: PropTypes.func,
-  brands: PropTypes.array,
   onFilters: PropTypes.func,
   filters: PropTypes.object,
   reset: PropTypes.func,

--- a/src/sections/campaign/discover/admin/view/campaign-view.jsx
+++ b/src/sections/campaign/discover/admin/view/campaign-view.jsx
@@ -2,7 +2,6 @@ import React, { useState, useCallback } from 'react';
 
 import {
   Box,
-  Menu,
   Stack,
   Avatar,
   Button,
@@ -19,6 +18,7 @@ import { useRouter } from 'src/routes/hooks';
 
 import { useBoolean } from 'src/hooks/use-boolean';
 import useGetCampaigns from 'src/hooks/use-get-campaigns';
+import { useGetCampaignBrandOption } from 'src/hooks/use-get-company-brand';
 
 import Iconify from 'src/components/iconify';
 import { useSettingsContext } from 'src/components/settings';
@@ -36,16 +36,10 @@ const defaultFilters = {
 const CampaignView = () => {
   const settings = useSettingsContext();
   const { campaigns } = useGetCampaigns();
+  const { data: brandOptions } = useGetCampaignBrandOption();
+  
   const router = useRouter();
-
-  const [anchorEl, setAnchorEl] = useState(null);
   const [filters, setFilters] = useState(defaultFilters);
-
-  const open = Boolean(anchorEl);
-
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
 
   const openFilters = useBoolean();
 
@@ -135,19 +129,6 @@ const CampaignView = () => {
         <Button onClick={openFilters.onTrue} endIcon={<Iconify icon="ic:round-filter-list" />}>
           Filter
         </Button>
-
-        <Menu
-          id="basic-menu"
-          anchorEl={anchorEl}
-          open={open}
-          onClose={handleClose}
-          MenuListProps={{
-            'aria-labelledby': 'basic-button',
-          }}
-        >
-          <MenuItem>Active</MenuItem>
-          <MenuItem>Past</MenuItem>
-        </Menu>
       </Stack>
 
       {dataFiltered && dataFiltered.length > 0 ? (
@@ -163,6 +144,7 @@ const CampaignView = () => {
         filters={filters}
         onFilters={handleFilters}
         reset={handleResetFitlers}
+        brands={brandOptions}
       />
     </Container>
   );


### PR DESCRIPTION
1) Implement brand-based sorting on the Admin and Super Admin pages based on selected brands.
2) Add a dropdown menu that displays a list of existing clients and brands.
3) Enable a search feature within the dropdown menu, allowing users to easily find specific clients and brands.
4) Integrate the selected filters inside campaign view, that users  can filter campaigns based on the selected brands or clients.