### PR TITLE
CC-0001 Registered users spreadsheet for Super Admin

### DIFF
--- a/src/sections/creator/creator-list-table/view/creator-table-view.jsx
+++ b/src/sections/creator/creator-list-table/view/creator-table-view.jsx
@@ -81,6 +81,7 @@ function CreatorTableView() {
   const [openCreateDialog, setOpenCreateDialog] = useState(false);
   const [ageRange, setAgeRange] = useState(defaultFilters.ageRange);
   const { user: admin } = useAuthContext();
+  const [isExporting, setIsExporting] = useState(false);
 
   const handleAgeRangeChange = (newValue) => {
     setAgeRange(newValue);
@@ -109,6 +110,32 @@ function CreatorTableView() {
 
   const handleClose = () => {
     setAnchorEl(null);
+  };
+
+  const handleExportToSpreadsheet = async () => {
+    try {
+      setIsExporting(true);
+      const response = await axiosInstance.get(endpoints.creators.exportCreators);
+      
+      if (response.data && response.data.url) {
+        // Open the spreadsheet in a new tab
+        const a = document.createElement('a');
+        a.href = response.data.url;
+        a.target = '_blank';
+        a.rel = 'noopener noreferrer';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        
+        enqueueSnackbar('Creators exported to spreadsheet successfully', { variant: 'success' });
+      }
+    } catch (error) {
+      console.log(`Spreadsheet url: ${process.env.REGISTERED_CREATORS_SPREADSHEET_ID}`);
+      console.error('Error exporting creators to spreadsheet: ', error);
+      enqueueSnackbar('Failed to export creators to spreadsheet', { variant: 'error' });
+    } finally {
+      setIsExporting(false);
+    }
   };
 
   const table = useTable();
@@ -218,6 +245,33 @@ function CreatorTableView() {
             { name: 'Creators' },
             { name: 'List' },
           ]}
+          action={
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<Iconify icon="tabler:external-link" width={16} />}
+              onClick={handleExportToSpreadsheet}
+              disabled={isExporting}
+              sx={{
+                height: 32,
+                borderRadius: 1,
+                color: '#221f20',
+                border: '1px solid #e7e7e7',
+                textTransform: 'none',
+                fontWeight: 600,
+                fontSize: '0.85rem',
+                px: 1.5,
+                whiteSpace: 'nowrap',
+                '&:hover': {
+                  border: '1px solid #e7e7e7',
+                  backgroundColor: 'rgba(34, 31, 32, 0.04)',
+                },
+                boxShadow: (theme) => `0px 2px 1px 1px ${theme.palette.grey[400]}`,
+              }}
+            >
+              {isExporting ? 'Exporting...' : 'Google Spreadsheet'}
+            </Button>
+          }
           sx={{
             mb: { xs: 3, md: 5 },
           }}

--- a/src/utils/axios.js
+++ b/src/utils/axios.js
@@ -109,6 +109,7 @@ export const endpoints = {
       instagram: (id) => `/api/social/instagram/overview/${id}`,
     },
     updatePreference: (id) => `/api/creator/updatePreference/${id}`,
+    exportCreators: '/api/creator/exportCreators',
   },
   users: {
     newAdmin: '/api/user/admins',


### PR DESCRIPTION
This pull request introduces a new feature to export registered creators' data to a Google Spreadsheet from the Creator Table View. Here are the key updates included in this pull request:

1. **New Export Functionality**:
   - Added a button labeled "Google Spreadsheet" in the Creator Table View interface.
   - Clicking the button triggers the `handleExportToSpreadsheet` function, which initiates an API call to fetch the spreadsheet data and opens it in a new tab.
   - The button provides user feedback by displaying "Exporting..." while the export process is ongoing and disables itself temporarily during this process.

2. **API Integration**:
   - A new API endpoint, `/api/creator/exportCreators`, has been added to the `endpoints` object in `src/utils/axios.js`. This endpoint facilitates the export operation.

3. **User Notifications**:
   - Success and error notifications are displayed to the user using `enqueueSnackbar`.
   - Notifications inform the user whether the export was successful or if there was an error during the process.

4. **Code Enhancements**:
   - Introduced a new state variable `isExporting` to manage the export button's loading state.
   - Ensured proper error handling and logging for debugging any issues with the export functionality.

These changes improve the user experience by enabling easy data export to Google Spreadsheets, which is particularly useful for administrative tasks or data analysis.