### PR TITLE
Fix: Preserve pagination state on back navigation

### DIFF
--- a/src/sections/report/view/reporting-view.jsx
+++ b/src/sections/report/view/reporting-view.jsx
@@ -249,7 +249,27 @@ const ReportingView = () => {
   }, [searchParams, fetchContentData]);
 
   const handleBack = () => {
-    navigate('/dashboard/report');
+    // Get return navigation state from URL params
+    const returnPage = searchParams.get('returnPage');
+    const returnCampaign = searchParams.get('returnCampaign');
+    
+    // Build the return URL with preserved state
+    let returnUrl = '/dashboard/report';
+    const params = new URLSearchParams();
+    
+    if (returnPage && returnPage !== '1') {
+      params.set('page', returnPage);
+    }
+    
+    if (returnCampaign && returnCampaign !== 'all') {
+      params.set('campaign', returnCampaign);
+    }
+    
+    if (params.toString()) {
+      returnUrl += `?${params.toString()}`;
+    }
+    
+    navigate(returnUrl);
   };
 
   const renderCircularStat = ({ width, label, value, metricKey }) => {


### PR DESCRIPTION
## Summary:
Fixed issue where clicking back from a performance report would reset users to page 1 instead of returning to their previous pagination state.

### **Changes Made:**
- Added URL parameter tracking for current page and campaign filter in `CampaignPerformanceTable`
- Modified `handleViewReport` to pass return state parameters
- Updated `ReportingView` back button to restore previous pagination state
- All pagination controls now update URL state for proper browser history

**Impact:** Users now return to the exact page and filter they were viewing when navigating back from report details.