### PR TITLE
CCB-327 Bugfix: missing currency

### DIFF
--- a/src/sections/creator/invoice/invoice-pdf.jsx
+++ b/src/sections/creator/invoice/invoice-pdf.jsx
@@ -112,6 +112,7 @@ const useStyles = () =>
 
 const InvoicePDF = ({ data }) => {
   const styles = useStyles();
+  console.log('invoice data: ', data)
 
   return (
     <Document>
@@ -285,7 +286,7 @@ const InvoicePDF = ({ data }) => {
                       fontSize: '10px',
                     }}
                   >
-                    {data?.campaign?.subscription?.currency} {data?.amount}
+                    {data?.campaign?.subscription?.currency || 'MYR'} {data?.amount}
                   </Text>
                 </View>
 

--- a/src/sections/invoice/view/invoice-list-view.jsx
+++ b/src/sections/invoice/view/invoice-list-view.jsx
@@ -680,7 +680,7 @@ export default function InvoiceListView({ campId, invoices }) {
                             />
                           </TableCell>
 
-                          <TableCell sx={{ width: 100 }}>{`${row.campaign?.subscription?.currency || ''} ${row.amount || 0}`}</TableCell>
+                          <TableCell sx={{ width: 100 }}>{`${row.campaign?.subscription?.currency || 'MYR'} ${row.amount || 0}`}</TableCell>
 
                           <TableCell sx={{ width: 100 }}>
                             <Typography


### PR DESCRIPTION
## Summary

### Problem:
The current code fetches a campaign's subscription currency in cases where the campaigns are not based in Malaysian Ringgit. However, not all campaigns have a subscription, hence the invoice's currency was missing due to missing subscription IDs for those campaigns.

### Solution:
Added the default value to be MYR if no subscription data exists for an invoice's campaign.

## Related Issues
- Related to: #252