### PR TITLE
CCD-166 Fix: Nofication route for creator deliverables

### DIFF
--- a/src/layouts/common/notifications-popover/notification-item.jsx
+++ b/src/layouts/common/notifications-popover/notification-item.jsx
@@ -26,7 +26,10 @@ export default function NotificationItem({ notification, markAsRead }) {
   const handleViewClick = () => {
     const { entity, campaignId, threadId, creatorId, invoiceId } = notification.notification ?? {};
 
+    console.log('Debug notification: ', notification.notification)
+
     let link = '';
+    let tabToSet = null;
 
     // the cases are entity
     switch (entity) {
@@ -42,19 +45,22 @@ export default function NotificationItem({ notification, markAsRead }) {
 
       case 'Agreement':
         link = user.role.includes('admin')
-          ? `/dashboard/campaign/discover/detail/${campaignId}/creator/${creatorId}`
+          ? `/dashboard/campaign/discover/detail/${campaignId}`
           : `/dashboard/campaign/VUquQR/HJUboKDBwJi71KQ==/manage/detail/${campaignId}`;
+        tabToSet = user.role.includes('admin') ? 'agreement' : null;
         break;
 
       case 'Draft':
         link = user.role.includes('admin')
-          ? `/dashboard/campaign/discover/detail/${campaignId}/creator/${creatorId}`
+          ? `/dashboard/campaign/discover/detail/${campaignId}`
           : `/dashboard/campaign/VUquQR/HJUboKDBwJi71KQ==/manage/detail/${campaignId}`;
+        tabToSet = user.role.includes('admin') ? 'deliverables' : null;
         break;
       case 'Post':
         link = user.role.includes('admin')
-          ? `/dashboard/campaign/discover/detail/${campaignId}/creator/${creatorId}`
+          ? `/dashboard/campaign/discover/detail/${campaignId}`
           : `/dashboard/campaign/VUquQR/HJUboKDBwJi71KQ==/manage/detail/${campaignId}`;
+        tabToSet = user.role.includes('admin') ? 'deliverables' : null;
         break;
 
       case 'Chat':
@@ -90,6 +96,16 @@ export default function NotificationItem({ notification, markAsRead }) {
 
     if (notification.read === false) {
       markAsRead(notification.id);
+    }
+
+    // Set the appropriate tab for admin notifications
+    if (tabToSet) {
+      localStorage.setItem('campaigndetail', tabToSet);
+      
+      // For deliverables tab, also store the creator ID to pre-select them
+      if (tabToSet === 'deliverables' && creatorId) {
+        localStorage.setItem('targetCreatorId', creatorId);
+      }
     }
 
     if (link) {

--- a/src/layouts/common/notifications-popover/notification-item.jsx
+++ b/src/layouts/common/notifications-popover/notification-item.jsx
@@ -26,8 +26,6 @@ export default function NotificationItem({ notification, markAsRead }) {
   const handleViewClick = () => {
     const { entity, campaignId, threadId, creatorId, invoiceId } = notification.notification ?? {};
 
-    console.log('Debug notification: ', notification.notification)
-
     let link = '';
     let tabToSet = null;
 

--- a/src/sections/campaign/discover/admin/campaign-creator-deliverables.jsx
+++ b/src/sections/campaign/discover/admin/campaign-creator-deliverables.jsx
@@ -78,10 +78,27 @@ const CampaignCreatorDeliverables = ({ campaign }) => {
     setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
   };
 
-  // Set first creator as selected by default
+  // Set first creator as selected by default, or use target creator from localStorage
   useEffect(() => {
     if (sortedCreators?.length && !selectedCreator) {
-      setSelectedCreator(sortedCreators[0]);
+      // Check if there's a target creator ID from notification
+      const targetCreatorId = localStorage.getItem('targetCreatorId');
+      
+      if (targetCreatorId) {
+        // Find the specific creator to select
+        const targetCreator = sortedCreators.find(creator => creator.userId === targetCreatorId);
+        if (targetCreator) {
+          setSelectedCreator(targetCreator);
+          // Clear the target creator ID after using it
+          localStorage.removeItem('targetCreatorId');
+        } else {
+          // Fallback to first creator if target not found
+          setSelectedCreator(sortedCreators[0]);
+        }
+      } else {
+        // Default behavior - select first creator
+        setSelectedCreator(sortedCreators[0]);
+      }
     }
   }, [sortedCreators, selectedCreator]);
 


### PR DESCRIPTION
When the admin clicks on the notifications related to a creator deliverable, it should redirect them to the Creator Deliverables tab and the specific creator assigned to that deliverable.