### PR TITLE
CCD-173 Feat: Multiple posting links submission feature

### DIFF
--- a/src/sections/campaign/discover/admin/creator-stuff/submissions/posting/posting.jsx
+++ b/src/sections/campaign/discover/admin/creator-stuff/submissions/posting/posting.jsx
@@ -257,26 +257,73 @@ const Posting = ({ campaign, submission, creator }) => {
                           wordBreak: 'break-all',
                         }}
                       >
-                        <Typography
-                          variant="body2"
-                          component="a"
-                          href={submission?.content}
-                          target="_blank"
-                          rel="noopener"
-                          sx={{
-                            wordBreak: 'break-all',
-                            overflowWrap: 'break-word',
-                            color: 'primary.main',
-                            textDecoration: 'none',
-                            '&:hover': {
-                              textDecoration: 'underline',
-                            },
-                            maxWidth: '100%',
-                            display: 'inline-block',
-                          }}
-                        >
-                          {submission?.content}
-                        </Typography>
+                        {submission?.videos && submission.videos.length > 0 ? (
+                          <Stack spacing={1.5} sx={{ mt: 1, mb: 2 }}>
+                            {submission.videos.map((link, index) => (
+                              <Box 
+                                key={index} 
+                                sx={{
+                                  padding: '8px 12px',
+                                  backgroundColor: '#f8f9fa',
+                                  borderRadius: '8px',
+                                  border: '1px solid #e9ecef',
+                                  transition: 'all 0.2s ease',
+                                  '&:hover': {
+                                    backgroundColor: '#e3f2fd',
+                                    borderColor: '#2196f3',
+                                    transform: 'translateY(-1px)',
+                                    boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
+                                  }
+                                }}
+                              >
+                                <Typography
+                                  variant="body2"
+                                  component="a"
+                                  href={link}
+                                  target="_blank"
+                                  rel="noopener"
+                                  sx={{
+                                    wordBreak: 'break-all',
+                                    overflowWrap: 'break-word',
+                                    color: 'primary.main',
+                                    textDecoration: 'none',
+                                    fontWeight: 500,
+                                    fontSize: 14,
+                                    '&:hover': {
+                                      textDecoration: 'underline',
+                                      color: 'primary.dark',
+                                    },
+                                    maxWidth: '100%',
+                                    display: 'inline-block',
+                                  }}
+                                >
+                                  {link}
+                                </Typography>
+                              </Box>
+                            ))}
+                          </Stack>
+                        ) : (
+                          <Typography
+                            variant="body2"
+                            component="a"
+                            href={submission?.content}
+                            target="_blank"
+                            rel="noopener"
+                            sx={{
+                              wordBreak: 'break-all',
+                              overflowWrap: 'break-word',
+                              color: 'primary.main',
+                              textDecoration: 'none',
+                              '&:hover': {
+                                textDecoration: 'underline',
+                              },
+                              maxWidth: '100%',
+                              display: 'inline-block',
+                            }}
+                          >
+                            {submission?.content}
+                          </Typography>
+                        )}
                       </Box>
                     </Box>
                   </Box>
@@ -383,23 +430,66 @@ const Posting = ({ campaign, submission, creator }) => {
 
                   <Box sx={{ pl: 7 }}>
                     <Box sx={{ mt: -4.5 }}>
-                      <Typography
-                        variant="body2"
-                        component="a"
-                        href={submission?.content}
-                        target="_blank"
-                        rel="noopener"
-                        sx={{
-                          wordBreak: 'break-word',
-                          color: 'primary.main',
-                          textDecoration: 'none',
-                          '&:hover': {
-                            textDecoration: 'underline',
-                          },
-                        }}
-                      >
-                        {submission?.content}
-                      </Typography>
+                      {submission?.videos && submission.videos.length > 0 ? (
+                        <Stack spacing={1.5} sx={{ mt: 1, mb: 2 }}>
+                          {submission.videos.map((link, index) => (
+                            <Box 
+                              key={index}
+                              sx={{
+                                padding: '8px 12px',
+                                backgroundColor: '#f8f9fa',
+                                borderRadius: '8px',
+                                border: '1px solid #e9ecef',
+                                transition: 'all 0.2s ease',
+                                '&:hover': {
+                                  backgroundColor: '#e3f2fd',
+                                  borderColor: '#2196f3',
+                                  transform: 'translateY(-1px)',
+                                  boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
+                                }
+                              }}
+                            >
+                              <Typography
+                                variant="body2"
+                                component="a"
+                                href={link}
+                                target="_blank"
+                                rel="noopener"
+                                sx={{
+                                  wordBreak: 'break-word',
+                                  color: 'primary.main',
+                                  textDecoration: 'none',
+                                  fontWeight: 500,
+                                  '&:hover': {
+                                    textDecoration: 'underline',
+                                    color: 'primary.dark',
+                                  },
+                                }}
+                              >
+                                {link}
+                              </Typography>
+                            </Box>
+                          ))}
+                        </Stack>
+                      ) : (
+                        <Typography
+                          variant="body2"
+                          component="a"
+                          href={submission?.content}
+                          target="_blank"
+                          rel="noopener"
+                          sx={{
+                            wordBreak: 'break-word',
+                            color: 'primary.main',
+                            textDecoration: 'none',
+                            '&:hover': {
+                              textDecoration: 'underline',
+                            },
+                          }}
+                        >
+                          {submission?.content}
+                        </Typography>
+                      )}
                     </Box>
                   </Box>
                 </Box>
@@ -448,23 +538,67 @@ const Posting = ({ campaign, submission, creator }) => {
                 borderColor: 'divider',
               }}
             >
-              <Typography
-                variant="body2"
-                component="a"
-                href={submission?.content}
-                target="_blank"
-                rel="noopener"
-                sx={{
-                  wordBreak: 'break-word',
-                  color: 'primary.main',
-                  textDecoration: 'none',
-                  '&:hover': {
-                    textDecoration: 'underline',
-                  },
-                }}
-              >
-                {submission?.content}
-              </Typography>
+              {submission?.videos && submission.videos.length > 0 ? (
+                <Stack spacing={1.5}>
+                  {submission.videos.map((link, index) => (
+                    <Box 
+                      key={index}
+                      sx={{
+                        padding: '10px 14px',
+                        backgroundColor: '#f8f9fa',
+                        borderRadius: '8px',
+                        border: '1px solid #e9ecef',
+                        transition: 'all 0.2s ease',
+                        '&:hover': {
+                          backgroundColor: '#e3f2fd',
+                          borderColor: '#2196f3',
+                          transform: 'translateY(-1px)',
+                          boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
+                        }
+                      }}
+                    >
+                      <Typography
+                        variant="body2"
+                        component="a"
+                        href={link}
+                        target="_blank"
+                        rel="noopener"
+                        sx={{
+                          wordBreak: 'break-word',
+                          color: 'primary.main',
+                          textDecoration: 'none',
+                          fontWeight: 500,
+                          fontSize: 14,
+                          '&:hover': {
+                            textDecoration: 'underline',
+                            color: 'primary.dark',
+                          },
+                        }}
+                      >
+                        {link}
+                      </Typography>
+                    </Box>
+                  ))}
+                </Stack>
+              ) : (
+                <Typography
+                  variant="body2"
+                  component="a"
+                  href={submission?.content}
+                  target="_blank"
+                  rel="noopener"
+                  sx={{
+                    wordBreak: 'break-word',
+                    color: 'primary.main',
+                    textDecoration: 'none',
+                    '&:hover': {
+                      textDecoration: 'underline',
+                    },
+                  }}
+                >
+                  {submission?.content}
+                </Typography>
+              )}
             </Box>
           </Stack>
         </DialogContent>


### PR DESCRIPTION
## Summary
Enhanced the posting link submission process to allow creators to submit multiple social media links and improved the admin review interface with better visual presentation.

## Changes Made
### Creators
- Multiple Link Support: Creators can now add multiple posting links instead of just one
- Dynamic Form Fields: "Add Another Link" button appears after entering the first link
- Improved UX: Always shows at least one input field, with individual delete buttons for additional links
- Form Validation: Ensures at least one valid link is required for submission

### Admins
- Individual Clickable Links: Admin now sees each posting link as a separate, clickable item
- Enhanced Visual Design: Links appear as styled cards with hover effects and clean spacing

### Technical Implementation
- Backend: Repurposed existing videos array field in Submission model to store multiple links
- Backward Compatibility: Maintains content field with concatenated links for legacy support
- Form Management: Robust field array handling with proper reset functionality