### PR TITLE
CCB-333 Fix: Invoice name filtering to search creator names

### DIFF
--- a/src/sections/invoice/view/invoice-list-view.jsx
+++ b/src/sections/invoice/view/invoice-list-view.jsx
@@ -890,7 +890,7 @@ function applyFilter({ inputData, comparator, filters, dateError }) {
     inputData = inputData?.filter(
       (invoice) =>
         invoice.invoiceNumber.toLowerCase().indexOf(name.toLowerCase()) !== -1 ||
-        invoice.invoiceTo.name.toLowerCase().indexOf(name.toLowerCase()) !== -1
+        invoice.invoiceFrom?.name?.toLowerCase().indexOf(name.toLowerCase()) !== -1
     );
   }
 


### PR DESCRIPTION
  Fixes name filter not working by changing search from `invoiceTo.name` to `invoiceFrom.name` to match what's
  displayed in the table (creator names).