### PR TITLE
Fix: Invoice currency display

### DIFF
--- a/src/sections/creator/invoice/invoice-pdf.jsx
+++ b/src/sections/creator/invoice/invoice-pdf.jsx
@@ -112,7 +112,6 @@ const useStyles = () =>
 
 const InvoicePDF = ({ data }) => {
   const styles = useStyles();
-  console.log('invoice data: ', data)
 
   return (
     <Document>
@@ -286,7 +285,7 @@ const InvoicePDF = ({ data }) => {
                       fontSize: '10px',
                     }}
                   >
-                    {data?.campaign?.subscription?.currency || 'MYR'} {data?.amount}
+                    {data?.creatorCurrency || 'MYR'} {data?.amount}
                   </Text>
                 </View>
 

--- a/src/sections/finance/invoice-item.jsx
+++ b/src/sections/finance/invoice-item.jsx
@@ -1,21 +1,42 @@
 import dayjs from 'dayjs';
 import PropTypes from 'prop-types';
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
+
+import { useGetAgreements } from 'src/hooks/use-get-agreeements';
 
 import { Box, Button, TableRow, Checkbox, TableCell, Typography } from '@mui/material';
 
 import Label from 'src/components/label';
 
-const InvoiceItem = ({ invoice, onChangeStatus, selected, onSelectRow, openEditInvoice }) => {
-  const [value, setValue] = useState(invoice?.status);
+const InvoiceItem = ({ invoice, selected, onSelectRow, openEditInvoice }) => {
+  // Currency mapping
+  const CURRENCY_PREFIXES = {
+    SGD: '$',
+    MYR: 'RM',
+    AUD: '$',
+    JPY: '¥',
+    IDR: 'Rp',
+    USD: '$',
+  };
 
-  useEffect(() => {
-    setValue(invoice?.status);
-  }, [setValue, invoice]);
+  // Fetch creator agreement for the campaign
+  const campaignId = invoice?.campaign?.id;
+  const { data: agreements } = useGetAgreements(campaignId);
+
+  // Get the currency for this specific invoice
+  const invoiceCurrency = useMemo(() => {
+    if (!agreements?.length || !invoice?.creator?.user?.id) return 'MYR';
+
+    const creatorId = invoice.creator.user.id;
+    const agreement = agreements.find((ag) => ag.user?.id === creatorId);
+
+    return agreement?.user?.shortlisted?.[0]?.currency || agreement?.currency || 'MYR';
+  }, [agreements, invoice?.creator?.user?.id]);
 
   const formatAmount = (amount) => {
     const numericAmount = parseFloat(amount.toString().replace(/[^0-9.-]+/g, ''));
-    return `RM${numericAmount.toLocaleString()}`;
+    const currencyPrefix = CURRENCY_PREFIXES[invoiceCurrency] || 'RM';
+    return `${currencyPrefix}${numericAmount.toLocaleString()}`;
   };
 
   return (
@@ -75,7 +96,6 @@ export default InvoiceItem;
 
 InvoiceItem.propTypes = {
   invoice: PropTypes.object,
-  onChangeStatus: PropTypes.func,
   selected: PropTypes.string,
   onSelectRow: PropTypes.func,
   openEditInvoice: PropTypes.func,

--- a/src/sections/invoice/view/invoice-list-view.jsx
+++ b/src/sections/invoice/view/invoice-list-view.jsx
@@ -50,6 +50,7 @@ import {
 } from 'src/components/table';
 
 import InvoiceTableFiltersResult from '../invoice-table-filters-result';
+import { useGetAgreements } from 'src/hooks/use-get-agreeements';
 
 // ----------------------------------------------------------------------
 
@@ -78,6 +79,8 @@ export default function InvoiceListView({ campId, invoices }) {
   const settings = useSettingsContext();
 
   const { user } = useAuthContext();
+
+  const { data, isLoading, error } = useGetAgreements(campId);
 
   const router = useRouter();
 
@@ -254,6 +257,24 @@ export default function InvoiceListView({ campId, invoices }) {
   const isDisabled = useMemo(
     () => user?.admin?.role?.name === 'Finance' && user?.admin?.mode === 'advanced',
     [user]
+  );
+
+  console.log('creatorAgreement Data: ', data);
+
+  const getCreatorAgreementCurrency = useCallback(
+    (row) => {
+      if (!data || !Array.isArray(data)) return 'MYR';
+
+      const creatorAgreement = data.find(
+        (agreement) =>
+          agreement?.user?.id === row?.invoiceFrom?.id || agreement?.userId === row?.invoiceFrom?.id
+      );
+
+      return (
+        creatorAgreement?.user?.shortlisted?.[0]?.currency || creatorAgreement?.currency || 'MYR'
+      );
+    },
+    [data]
   );
 
   const handleToggleSort = () => {
@@ -680,7 +701,9 @@ export default function InvoiceListView({ campId, invoices }) {
                             />
                           </TableCell>
 
-                          <TableCell sx={{ width: 100 }}>{`${row.campaign?.subscription?.currency || 'MYR'} ${row.amount || 0}`}</TableCell>
+                          <TableCell
+                            sx={{ width: 100 }}
+                          >{`${getCreatorAgreementCurrency(row)} ${row.amount || 0}`}</TableCell>
 
                           <TableCell sx={{ width: 100 }}>
                             <Typography


### PR DESCRIPTION
Previously, currencies on invoices were inconsistently being displayed. Problem was that currencies depended on campaign subscription's currency. Modified it to fetch currencies based on creator agreements. 

- Related to issue #266 