### PR TITLE
CCD-203 Fix: Invoice currency display

### DIFF
--- a/src/sections/campaign/discover/admin/campaign-agreements.jsx
+++ b/src/sections/campaign/discover/admin/campaign-agreements.jsx
@@ -412,10 +412,6 @@ const CampaignAgreements = ({ campaign }) => {
   const { user } = useAuthContext();
 
   const smUp = useResponsive('up', 'sm');
-  const mdUp = useResponsive('up', 'md');
-
-  const pendingCount = data?.filter((item) => !item.isSent).length || 0;
-  const sentCount = data?.filter((item) => item.isSent).length || 0;
 
   // Toggle sort direction
   const handleToggleSort = () => {
@@ -506,13 +502,13 @@ const CampaignAgreements = ({ campaign }) => {
   const handleSendAgreement = async (item) => {
     try {
       // Use different endpoints based on whether it's a resend or initial send
-      const endpoint = item.isSent ? endpoints.campaign.resendAgreement : endpoints.campaign.sendAgreement;
-      
+      const endpoint = item.isSent
+        ? endpoints.campaign.resendAgreement
+        : endpoints.campaign.sendAgreement;
+
       // For resend, use different payload format
-      const payload = item.isSent 
-        ? { userId: item.userId, campaignId: item.campaignId }
-        : item;
-      
+      const payload = item.isSent ? { userId: item.userId, campaignId: item.campaignId } : item;
+
       const res = await axiosInstance.patch(endpoint, payload);
       mutate(endpoints.campaign.creatorAgreement(item?.campaignId));
       enqueueSnackbar(res?.data?.message);
@@ -972,17 +968,11 @@ const CampaignAgreements = ({ campaign }) => {
                         <>
                           {item?.user?.shortlisted[0]?.currency ? (
                             <>
-                              {item?.user?.shortlisted[0]?.currency === 'SGD' && '$ '}
-                              {item?.user?.shortlisted[0]?.currency === 'MYR' && 'RM '}
-                              {item?.user?.shortlisted[0]?.currency === 'AUD' && '$ '}
-                              {item?.user?.shortlisted[0]?.currency === 'JPY' && '¥ '}
-                              {item?.user?.shortlisted[0]?.currency === 'IDR' && 'Rp '}
-                              {item?.user?.shortlisted[0]?.currency === 'USD' && '$ '}
-                              {parseFloat(item?.amount?.toString()) ||
-                                parseFloat(item?.user?.shortlisted[0]?.amount?.toString())}
+                              {`${item?.user?.shortlisted[0]?.currency} 
+                              ${parseFloat(item?.amount?.toString()) || parseFloat(item?.user?.shortlisted[0]?.amount?.toString())}`}
                             </>
                           ) : (
-                            <>{`RM ${parseFloat(item?.amount?.toString())}`}</>
+                            <>{`${item?.user?.shortlisted[0]?.currency} ${parseFloat(item?.amount?.toString())}`}</>
                           )}
                         </>
                       ) : (

--- a/src/sections/creator/invoice/invoice-lists.jsx
+++ b/src/sections/creator/invoice/invoice-lists.jsx
@@ -74,7 +74,7 @@ const InvoiceLists = ({ invoices }) => {
                   </Stack>
                 </TableCell>
                 <TableCell>{dayjs(invoice.issued).format('LL')}</TableCell>
-                <TableCell>{formatCurrencyAmount(invoice.amount, invoice.campaign.creatorAgreement[0]?.currency || 'MYR')}</TableCell>
+                <TableCell>{formatCurrencyAmount(invoice.amount, invoice.campaign?.creatorAgreement?.[0]?.currency || 'MYR')}</TableCell>
                 <TableCell>
                   <NewLabel
                     variant="soft"

--- a/src/sections/creator/invoice/invoice-lists.jsx
+++ b/src/sections/creator/invoice/invoice-lists.jsx
@@ -19,6 +19,7 @@ import {
 
 import { paths } from 'src/routes/paths';
 import { useRouter } from 'src/routes/hooks';
+import { formatCurrencyAmount } from 'src/utils/currency';
 
 import NewLabel from 'src/components/styleLabel/styleLabel';
 
@@ -73,7 +74,7 @@ const InvoiceLists = ({ invoices }) => {
                   </Stack>
                 </TableCell>
                 <TableCell>{dayjs(invoice.issued).format('LL')}</TableCell>
-                <TableCell>{`RM ${new Intl.NumberFormat('en-MY', { minimumFractionDigits: 0 }).format(invoice.amount)}`}</TableCell>
+                <TableCell>{formatCurrencyAmount(invoice.amount, invoice.campaign.creatorAgreement[0]?.currency || 'MYR')}</TableCell>
                 <TableCell>
                   <NewLabel
                     variant="soft"

--- a/src/sections/creator/invoice/invoice-pdf.jsx
+++ b/src/sections/creator/invoice/invoice-pdf.jsx
@@ -286,7 +286,7 @@ const InvoicePDF = ({ data }) => {
                       fontSize: '10px',
                     }}
                   >
-                    {data?.campaign?.subscription?.currency || 'MYR'} {data?.amount}
+                    {data?.campaign?.creatorAgreement[0]?.currency || data?.campaign?.subscription?.currency || 'MYR'} {data?.amount}
                   </Text>
                 </View>
 

--- a/src/sections/creator/invoice/invoice-pdf.jsx
+++ b/src/sections/creator/invoice/invoice-pdf.jsx
@@ -286,7 +286,7 @@ const InvoicePDF = ({ data }) => {
                       fontSize: '10px',
                     }}
                   >
-                    {data?.campaign?.creatorAgreement[0]?.currency || data?.campaign?.subscription?.currency || 'MYR'} {data?.amount}
+                    {data?.campaign?.creatorAgreement?.[0]?.currency || data?.campaign?.subscription?.currency || 'MYR'} {data?.amount}
                   </Text>
                 </View>
 

--- a/src/sections/finance/invoice-item.jsx
+++ b/src/sections/finance/invoice-item.jsx
@@ -5,6 +5,7 @@ import React, { useState, useEffect } from 'react';
 import { Box, Button, TableRow, Checkbox, TableCell, Typography } from '@mui/material';
 
 import Label from 'src/components/label';
+import { formatCurrencyAmount } from 'src/utils/currency';
 
 const InvoiceItem = ({ invoice, onChangeStatus, selected, onSelectRow, openEditInvoice }) => {
   const [value, setValue] = useState(invoice?.status);
@@ -13,10 +14,7 @@ const InvoiceItem = ({ invoice, onChangeStatus, selected, onSelectRow, openEditI
     setValue(invoice?.status);
   }, [setValue, invoice]);
 
-  const formatAmount = (amount) => {
-    const numericAmount = parseFloat(amount.toString().replace(/[^0-9.-]+/g, ''));
-    return `RM${numericAmount.toLocaleString()}`;
-  };
+
 
   return (
     <TableRow
@@ -46,7 +44,7 @@ const InvoiceItem = ({ invoice, onChangeStatus, selected, onSelectRow, openEditI
         <Typography variant="subtitle2">{dayjs(invoice?.createdAt).format('LL')}</Typography>
       </TableCell>
       <TableCell>
-        <Typography variant="subtitle2">{formatAmount(invoice?.amount)}</Typography>
+        <Typography variant="subtitle2">{formatCurrencyAmount(invoice?.amount, invoice?.currency || 'MYR')}</Typography>
       </TableCell>
       <TableCell>
         <Label

--- a/src/sections/invoice/invoice-new-edit-details.jsx
+++ b/src/sections/invoice/invoice-new-edit-details.jsx
@@ -26,6 +26,8 @@ export default function InvoiceNewEditDetails() {
 
   const totalOnRow = values.items.map((item) => item?.price);
 
+  const currency = values.items.map((item) => item?.currency)
+
   const subTotal = sum(totalOnRow);
 
   const totalAmount = subTotal;
@@ -70,7 +72,7 @@ export default function InvoiceNewEditDetails() {
     >
       <Stack direction="row" sx={{ typography: 'subtitle1' }}>
         <Box>Total</Box>
-        <Box sx={{ width: 160 }}>{`RM${totalAmount}` || '-'}</Box>
+        <Box sx={{ width: 160 }}>{`${currency} ${totalAmount}` || '-'}</Box>
       </Stack>
     </Stack>
   );
@@ -139,11 +141,11 @@ export default function InvoiceNewEditDetails() {
                 InputProps={{
                   startAdornment: (
                     <InputAdornment position="start">
-                      <Box sx={{ typography: 'subtitle2', color: 'text.disabled' }}>RM</Box>
+                      <Box sx={{ typography: 'subtitle2', color: 'text.disabled' }}>{currency}</Box>
                     </InputAdornment>
                   ),
                 }}
-                sx={{ maxWidth: { md: 96 } }}
+                sx={{ maxWidth: { md: 100 } }}
               />
 
               <RHFTextField
@@ -162,12 +164,12 @@ export default function InvoiceNewEditDetails() {
                 InputProps={{
                   startAdornment: (
                     <InputAdornment position="start">
-                      <Box sx={{ typography: 'subtitle2', color: 'text.disabled' }}>RM</Box>
+                      <Box sx={{ typography: 'subtitle2', color: 'text.disabled' }}>{values.items[index]?.currency}</Box>
                     </InputAdornment>
                   ),
                 }}
                 sx={{
-                  maxWidth: { md: 104 },
+                  maxWidth: { md: 120 },
                   [`& .${inputBaseClasses.input}`]: {
                     textAlign: { md: 'right' },
                   },

--- a/src/sections/invoice/invoice-new-edit-form.jsx
+++ b/src/sections/invoice/invoice-new-edit-form.jsx
@@ -193,8 +193,8 @@ export default function InvoiceNewEditForm({ id, creators }) {
           name: 'Cult Creative',
           email: 'support@cultcreative.asia',
           fullAddress:
-            '4-402, Level 4, The Starling Mall, Lot 4-401 &, 6, Jalan SS 21/37, Damansara Utama, 47400 Petaling Jaya, Selangor',
-          phoneNumber: '+60 11-5415 5751',
+            '5-3A, Block A, Jaya One, No.72A, Jalan Universiti, 46200 Petaling Jaya, Selangor',
+          phoneNumber: '(+60)12-849 6499',
           company: 'Cult Creative',
           addressType: 'Hq',
         },
@@ -204,6 +204,7 @@ export default function InvoiceNewEditForm({ id, creators }) {
           ...invoice?.task,
           campaignName: invoice?.campaign?.name,
           clientName: invoice?.campaign?.company?.name || invoice?.campaign?.brand?.name,
+          currency: invoice?.campaign?.creatorAgreement?.[0]?.currency || '',
         },
       ] || [
         {
@@ -213,6 +214,7 @@ export default function InvoiceNewEditForm({ id, creators }) {
           // description: '',
           service: '',
           quantity: 1,
+          currency: '',
           price: 0,
           total: 0,
         },

--- a/src/sections/invoice/invoice-pdf.jsx
+++ b/src/sections/invoice/invoice-pdf.jsx
@@ -186,10 +186,10 @@ export default function InvoicePDF({ invoice, currentStatus }) {
               </View>
 
               <View style={styles.tableCell_2}>
-                <Text style={styles.subtitle2}>Title</Text>
+                <Text style={styles.subtitle2}>Client Name</Text>
               </View>
               <View style={styles.tableCell_2}>
-                <Text style={styles.subtitle2}>Description</Text>
+                <Text style={styles.subtitle2}>Campaign Name</Text>
               </View>
 
               <View style={[styles.tableCell_2]}>
@@ -205,14 +205,14 @@ export default function InvoicePDF({ invoice, currentStatus }) {
               </View>
 
               <View style={[styles.tableCell_2]}>
-                <Text>{invoice?.task.title}</Text>
+                <Text>{invoice?.campaign.company?.name || invoice?.campaign.brand?.name}</Text>
               </View>
               <View style={styles.tableCell_2}>
-                <Text>{invoice?.task.description}</Text>
+                <Text>{invoice?.campaign?.name}</Text>
               </View>
 
               <View style={[styles.tableCell_2]}>
-                <Text>{`RM${invoice?.amount}`}</Text>
+                <Text>{`${invoice.campaign.creatorAgreement[0].currency} ${invoice?.amount}`}</Text>
               </View>
             </View>
 
@@ -224,7 +224,7 @@ export default function InvoicePDF({ invoice, currentStatus }) {
                 <Text style={styles.h4}>Total</Text>
               </View>
               <View style={[styles.tableCell_3, styles.alignRight]}>
-                <Text style={styles.h4}>{`RM${invoice?.amount}`}</Text>
+                <Text style={styles.h4}>{`${invoice.campaign.creatorAgreement[0].currency} ${invoice?.amount}`}</Text>
               </View>
             </View>
           </View>

--- a/src/sections/invoice/view/invoice-list-view.jsx
+++ b/src/sections/invoice/view/invoice-list-view.jsx
@@ -50,6 +50,7 @@ import {
 } from 'src/components/table';
 
 import InvoiceTableFiltersResult from '../invoice-table-filters-result';
+import { formatCurrencyAmount } from 'src/utils/currency';
 
 // ----------------------------------------------------------------------
 
@@ -680,7 +681,7 @@ export default function InvoiceListView({ campId, invoices }) {
                             />
                           </TableCell>
 
-                          <TableCell sx={{ width: 100 }}>{`${row.campaign?.subscription?.currency || 'MYR'} ${row.amount || 0}`}</TableCell>
+                          <TableCell sx={{ width: 100 }}>{formatCurrencyAmount(row.amount, row.currency)}</TableCell>
 
                           <TableCell sx={{ width: 100 }}>
                             <Typography

--- a/src/utils/currency.js
+++ b/src/utils/currency.js
@@ -1,0 +1,49 @@
+const CURRENCY_PREFIXES = {
+  SGD: {
+    prefix: '$',
+    label: 'SGD',
+  },
+  MYR: {
+    prefix: 'RM',
+    label: 'MYR',
+  },
+  AUD: {
+    prefix: '$',
+    label: 'AUD',
+  },
+  JPY: {
+    prefix: '¥',
+    label: 'JPY',
+  },
+  IDR: {
+    prefix: 'Rp',
+    label: 'IDR',
+  },
+  USD: {
+    prefix: '$',
+    label: 'USD',
+  },
+};
+
+export const getCurrencyPrefix = (currencyCode) => {
+  return CURRENCY_PREFIXES[currencyCode]?.prefix || '';
+};
+
+export const getCurrencyLabel = (currencyCode) => {
+  return CURRENCY_PREFIXES[currencyCode]?.label || currencyCode;
+};
+
+export const formatCurrencyAmount = (amount, currencyCode) => {
+  const prefix = getCurrencyPrefix(currencyCode);
+  const formattedAmount = new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  }).format(amount);
+  return `${prefix} ${formattedAmount}`;
+};
+
+export const getCurrencyData = (currencyCode) => {
+  return CURRENCY_PREFIXES[currencyCode] || { prefix: '', label: currencyCode };
+};
+
+export { CURRENCY_PREFIXES };

--- a/src/utils/currency.js
+++ b/src/utils/currency.js
@@ -25,16 +25,12 @@ const CURRENCY_PREFIXES = {
   },
 };
 
-export const getCurrencyPrefix = (currencyCode) => {
-  return CURRENCY_PREFIXES[currencyCode]?.prefix || '';
-};
+export const getCurrencyPrefix = (currencyCode) => CURRENCY_PREFIXES[currencyCode]?.prefix || '';
 
-export const getCurrencyLabel = (currencyCode) => {
-  return CURRENCY_PREFIXES[currencyCode]?.label || currencyCode;
-};
+export const getCurrencyLabel = (currencyCode) => CURRENCY_PREFIXES[currencyCode]?.label || currencyCode;
 
 export const formatCurrencyAmount = (amount, currencyCode) => {
-  const prefix = getCurrencyPrefix(currencyCode);
+  const prefix = getCurrencyLabel(currencyCode);
   const formattedAmount = new Intl.NumberFormat('en-US', {
     minimumFractionDigits: 0,
     maximumFractionDigits: 2,
@@ -42,8 +38,6 @@ export const formatCurrencyAmount = (amount, currencyCode) => {
   return `${prefix} ${formattedAmount}`;
 };
 
-export const getCurrencyData = (currencyCode) => {
-  return CURRENCY_PREFIXES[currencyCode] || { prefix: '', label: currencyCode };
-};
+export const getCurrencyData = (currencyCode) => CURRENCY_PREFIXES[currencyCode] || { prefix: '', label: currencyCode };
 
 export { CURRENCY_PREFIXES };


### PR DESCRIPTION
## Support Multiple Currencies in Invoice Module

### Overview

This PR introduces multi-currency support across the invoice-related components. The major changes include:

- **New Utility:** Added `src/utils/currency.js` to centralize currency formatting and prefix logic.
- **Currency Display:** All invoice tables, forms, and PDFs now use the correct currency prefix and code, not just "RM".
- **Invoice Form:** Currency is now part of the invoice item model and properly shown in form inputs, summaries, and generated PDFs.
- **Refactoring:** Removed duplicated formatting logic and replaced with `formatCurrencyAmount` utility.

### Main Changes

- Added `formatCurrencyAmount`, `getCurrencyPrefix`, and helpers to handle different currencies (`SGD`, `MYR`, `USD`, `AUD`, `JPY`, `IDR`).
- Updated `invoice-item.jsx`, `invoice-list-view.jsx`, `invoice-lists.jsx`, and PDF components to use new formatting.
- Enhanced invoice forms to allow and display item-level currency.
- Updated Cult Creative company info in invoice form.

### Why

These changes ensure that invoices are accurate for international clients and campaigns, and simplify maintenance by centralizing currency logic.