### PR TITLE
CCB-402 Fix: Missing creator signatures

### DIFF
--- a/src/hooks/use-get-v4-submissions.js
+++ b/src/hooks/use-get-v4-submissions.js
@@ -1,0 +1,60 @@
+import useSWR from 'swr';
+
+import axiosInstance, { endpoints, fetcher } from 'src/utils/axios';
+
+// ----------------------------------------------------------------------
+
+export const useGetV4Submissions = (campaignId, userId) => {
+  const URL = `${endpoints.submission.v4.getSubmissions}?campaignId=${campaignId}${userId ? `&userId=${userId}` : ''}`;
+  
+  const { data, isLoading, error, mutate } = useSWR(
+    campaignId ? URL : null,
+    fetcher,
+    {
+      revalidateIfStale: false,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+    }
+  );
+
+  const memoizedValue = {
+    submissions: data?.submissions || [],
+    grouped: data?.grouped || {},
+    total: data?.total || 0,
+    submissionsLoading: isLoading,
+    submissionsError: error,
+    submissionsMutate: mutate,
+  };
+
+  return memoizedValue;
+};
+
+// Create V4 submissions for creator
+export const createV4Submissions = async (data) => {
+  const response = await axiosInstance.post(endpoints.submission.v4.create, data);
+  return response.data;
+};
+
+// Submit content for V4 submission
+export const submitV4Content = async (data) => {
+  const response = await axiosInstance.post(endpoints.submission.v4.submitContent, data);
+  return response.data;
+};
+
+// Approve/Reject V4 submission
+export const approveV4Submission = async (data) => {
+  const response = await axiosInstance.post(endpoints.submission.v4.approve, data);
+  return response.data;
+};
+
+// Update posting link
+export const updateV4PostingLink = async (data) => {
+  const response = await axiosInstance.put(endpoints.submission.v4.postingLink, data);
+  return response.data;
+};
+
+// Get single V4 submission
+export const getV4SubmissionById = async (submissionId) => {
+  const response = await axiosInstance.get(`${endpoints.submission.v4.getById}/${submissionId}`);
+  return response.data;
+};

--- a/src/sections/campaign/discover/admin/campaign-agreements.jsx
+++ b/src/sections/campaign/discover/admin/campaign-agreements.jsx
@@ -229,11 +229,7 @@ const AgreementDialog = ({ open, onClose, url, agreement, campaign, onApprove, o
         </DialogTitle>
         <DialogContent>
           <iframe
-            src={
-              isPendingReview && agreement?.submission?.content
-                ? agreement?.submission?.content
-                : url
-            }
+            src={agreement?.submission?.content || url}
             title="Agreement"
             style={{ width: '100%', height: '600px', border: 'none' }}
           />

--- a/src/sections/campaign/discover/admin/campaign-creator-submissions-v4.jsx
+++ b/src/sections/campaign/discover/admin/campaign-creator-submissions-v4.jsx
@@ -1,0 +1,363 @@
+import PropTypes from 'prop-types';
+import { useState, useCallback } from 'react';
+
+import {
+  Box,
+  Card,
+  Chip,
+  Stack,
+  Avatar,
+  Button,
+  Dialog,
+  Divider,
+  TextField,
+  Typography,
+  IconButton,
+  DialogTitle,
+  DialogActions,
+  DialogContent,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+} from '@mui/material';
+
+import Iconify from 'src/components/iconify';
+import { useGetV4Submissions } from 'src/hooks/use-get-v4-submissions';
+
+import V4VideoSubmission from './submissions/v4/video-submission';
+import V4PhotoSubmission from './submissions/v4/photo-submission';
+import V4RawFootageSubmission from './submissions/v4/raw-footage-submission';
+
+// ----------------------------------------------------------------------
+
+export default function CampaignCreatorSubmissionsV4({ campaign }) {
+  const [selectedCreator, setSelectedCreator] = useState(null);
+  const [searchTerm, setSearchTerm] = useState('');
+
+  // Get V4 submissions for selected creator
+  const { 
+    submissions, 
+    grouped, 
+    submissionsLoading,
+    submissionsMutate 
+  } = useGetV4Submissions(campaign?.id, selectedCreator?.userId);
+
+  const handleSelectCreator = useCallback((creator) => {
+    setSelectedCreator(creator);
+  }, []);
+
+  // Calculate expected submissions for a creator based on campaign requirements
+  // Only shows content submissions (VIDEO, PHOTO, RAW_FOOTAGE) - Agreement is handled in separate tab
+  const getExpectedSubmissions = useCallback((creator) => {
+    const expectedSubmissions = [];
+    
+    // Add video submissions based on ugcVideos count
+    const ugcVideos = creator.ugcVideos || 0;
+    for (let i = 1; i <= ugcVideos; i++) {
+      expectedSubmissions.push({ type: 'VIDEO', label: `Video ${i}`, order: i });
+    }
+    
+    // Add photo submission if required
+    if (campaign?.photos) {
+      expectedSubmissions.push({ type: 'PHOTO', label: 'Photos' });
+    }
+    
+    // Add raw footage submission if required (single submission, multiple uploads like photos)
+    if (campaign?.rawFootage) {
+      expectedSubmissions.push({ type: 'RAW_FOOTAGE', label: 'Raw Footage' });
+    }
+    
+    return expectedSubmissions;
+  }, [campaign]);
+
+  const handleSearchChange = useCallback((event) => {
+    setSearchTerm(event.target.value);
+  }, []);
+
+  // Get submission status for expected submissions
+  const getSubmissionStatus = useCallback((creator, expectedType, order = null) => {
+    if (!submissions || submissions.length === 0) return 'Not Created';
+    
+    let matchingSubmission;
+    
+    if (order) {
+      // For videos and raw footage with specific order
+      matchingSubmission = submissions.find(s => 
+        s.submissionType.type === expectedType && s.contentOrder === order
+      );
+    } else {
+      // For photos (no specific order)
+      matchingSubmission = submissions.find(s => s.submissionType.type === expectedType);
+    }
+    
+    if (!matchingSubmission) return 'Not Created';
+    
+    // Return formatted status
+    return matchingSubmission.status?.replace(/_/g, ' ').toLowerCase()
+      .replace(/\b\w/g, l => l.toUpperCase()) || 'Unknown';
+  }, [submissions]);
+
+  // Get status color for display
+  const getStatusColor = useCallback((status) => {
+    if (status === 'Not Created') return 'default';
+    
+    const statusColors = {
+      'Pending Review': 'warning',
+      'In Progress': 'info', 
+      'Approved': 'success',
+      'Rejected': 'error',
+      'Changes Required': 'warning',
+      'Sent To Client': 'primary',
+      'Client Approved': 'success',
+      'Client Feedback': 'warning',
+      'Sent To Admin': 'info',
+    };
+    return statusColors[status] || 'default';
+  }, []);
+
+  // Filter creators based on search term
+  const filteredCreators = campaign?.shortlisted?.filter(creator => {
+    const name = creator.user?.name?.toLowerCase() || '';
+    const email = creator.user?.email?.toLowerCase() || '';
+    const searchLower = searchTerm.toLowerCase();
+    return name.includes(searchLower) || email.includes(searchLower);
+  }) || [];
+
+  // Only show V4 campaigns
+  if (campaign?.submissionVersion !== 'v4') {
+    return (
+      <Card sx={{ p: 3 }}>
+        <Typography variant="h6" color="text.secondary" textAlign="center">
+          V4 Creator Submissions
+        </Typography>
+        <Typography variant="body2" color="text.secondary" textAlign="center" sx={{ mt: 1 }}>
+          This tab is only available for V4 campaigns with content-type based submissions.
+        </Typography>
+        <Typography variant="caption" color="text.secondary" textAlign="center" display="block" sx={{ mt: 1 }}>
+          Current campaign version: {campaign?.submissionVersion || 'v3'}
+        </Typography>
+      </Card>
+    );
+  }
+
+  return (
+    <Box sx={{ height: '100%', display: 'flex' }}>
+      {/* Creator Sidebar */}
+      <Card sx={{ width: 350, mr: 2, display: 'flex', flexDirection: 'column' }}>
+        <Box sx={{ p: 2, borderBottom: 1, borderColor: 'divider' }}>
+          <Typography variant="h6" gutterBottom>
+            Creators ({filteredCreators.length})
+          </Typography>
+          <TextField
+            fullWidth
+            size="small"
+            placeholder="Search creators..."
+            value={searchTerm}
+            onChange={handleSearchChange}
+            InputProps={{
+              startAdornment: <Iconify icon="eva:search-fill" sx={{ color: 'text.disabled', mr: 1 }} />,
+            }}
+          />
+        </Box>
+
+        <Box sx={{ flex: 1, overflow: 'auto' }}>
+          {filteredCreators.length === 0 ? (
+            <Box sx={{ p: 3, textAlign: 'center' }}>
+              <Typography variant="body2" color="text.secondary">
+                No creators found
+              </Typography>
+            </Box>
+          ) : (
+            filteredCreators.map((creator, index) => {
+              const expectedSubmissions = getExpectedSubmissions(creator);
+              const isSelected = selectedCreator?.userId === creator.userId;
+              
+              // Calculate completion status for this creator
+              const completedCount = expectedSubmissions.filter(expected => {
+                const status = getSubmissionStatus(creator, expected.type, expected.order);
+                return status === 'Approved' || status === 'Client Approved';
+              }).length;
+              
+              const totalCount = expectedSubmissions.length;
+              
+              return (
+                <Box key={creator.userId || index}>
+                  <Button
+                    fullWidth
+                    onClick={() => handleSelectCreator(creator)}
+                    sx={{
+                      p: 2,
+                      justifyContent: 'flex-start',
+                      borderRadius: 0,
+                      bgcolor: isSelected ? 'action.selected' : 'transparent',
+                      '&:hover': {
+                        bgcolor: 'action.hover',
+                      },
+                    }}
+                  >
+                    <Avatar
+                      src={creator.user?.photoURL}
+                      alt={creator.user?.name}
+                      sx={{ width: 40, height: 40, mr: 2 }}
+                    >
+                      {creator.user?.name?.charAt(0).toUpperCase()}
+                    </Avatar>
+                    <Box sx={{ flex: 1, textAlign: 'left' }}>
+                      <Typography variant="subtitle2" noWrap>
+                        {creator.user?.name || 'Unknown Creator'}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary" noWrap>
+                        {creator.user?.email}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 0.5 }}>
+                        {completedCount}/{totalCount} submissions completed
+                      </Typography>
+                    </Box>
+                  </Button>
+                  
+                  {/* Show individual submissions when selected */}
+                  {isSelected && (
+                    <Box sx={{ pl: 2, pr: 1, pb: 1, bgcolor: 'action.selected' }}>
+                      <Stack spacing={0.5}>
+                        {expectedSubmissions.map((expected, submissionIndex) => {
+                          const status = getSubmissionStatus(creator, expected.type, expected.order);
+                          return (
+                            <Stack
+                              key={`${expected.type}-${expected.order || 0}`}
+                              direction="row"
+                              alignItems="center"
+                              justifyContent="space-between"
+                              sx={{ py: 0.5, px: 1 }}
+                            >
+                              <Typography variant="caption" color="text.secondary">
+                                {expected.label}
+                              </Typography>
+                              <Chip
+                                label={status}
+                                color={getStatusColor(status)}
+                                size="small"
+                                sx={{ 
+                                  height: 18, 
+                                  fontSize: '0.7rem',
+                                  '& .MuiChip-label': { px: 0.75 }
+                                }}
+                              />
+                            </Stack>
+                          );
+                        })}
+                      </Stack>
+                    </Box>
+                  )}
+                  
+                  {index < filteredCreators.length - 1 && <Divider />}
+                </Box>
+              );
+            })
+          )}
+        </Box>
+      </Card>
+
+      {/* Submissions Content */}
+      <Card sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        {selectedCreator ? (
+          <Box sx={{ flex: 1, overflow: 'auto' }}>
+            {/* Creator Header */}
+            <Box sx={{ p: 3, borderBottom: 1, borderColor: 'divider' }}>
+              <Stack direction="row" alignItems="center" spacing={2}>
+                <Avatar
+                  src={selectedCreator.user?.photoURL}
+                  alt={selectedCreator.user?.name}
+                  sx={{ width: 50, height: 50 }}
+                >
+                  {selectedCreator.user?.name?.charAt(0).toUpperCase()}
+                </Avatar>
+                <Box>
+                  <Typography variant="h6">
+                    {selectedCreator.user?.name || 'Unknown Creator'}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {selectedCreator.user?.email}
+                  </Typography>
+                </Box>
+              </Stack>
+            </Box>
+
+            {/* Loading State */}
+            {submissionsLoading && (
+              <Box sx={{ p: 3, textAlign: 'center' }}>
+                <Typography>Loading submissions...</Typography>
+              </Box>
+            )}
+
+            {/* Submissions */}
+            {!submissionsLoading && (
+              <Box sx={{ p: 2 }}>
+                {submissions.length === 0 ? (
+                  <Box sx={{ textAlign: 'center', py: 4 }}>
+                    <Typography variant="body1" color="text.secondary">
+                      No content submissions found for this creator
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                      Content submissions are created automatically when the creator's agreement is approved
+                    </Typography>
+                  </Box>
+                ) : (
+                  <Stack spacing={2}>
+                    {/* Video Submissions */}
+                    {grouped.videos?.map((videoSubmission, index) => (
+                      <V4VideoSubmission
+                        key={videoSubmission.id}
+                        submission={videoSubmission}
+                        campaign={campaign}
+                        index={index + 1}
+                        onUpdate={submissionsMutate}
+                      />
+                    ))}
+
+                    {/* Photo Submissions */}
+                    {grouped.photos?.map((photoSubmission, index) => (
+                      <V4PhotoSubmission
+                        key={photoSubmission.id}
+                        submission={photoSubmission}
+                        campaign={campaign}
+                        index={index + 1}
+                        onUpdate={submissionsMutate}
+                      />
+                    ))}
+
+                    {/* Raw Footage Submissions */}
+                    {grouped.rawFootage?.map((rawFootageSubmission, index) => (
+                      <V4RawFootageSubmission
+                        key={rawFootageSubmission.id}
+                        submission={rawFootageSubmission}
+                        campaign={campaign}
+                        index={index + 1}
+                        onUpdate={submissionsMutate}
+                      />
+                    ))}
+                  </Stack>
+                )}
+              </Box>
+            )}
+          </Box>
+        ) : (
+          <Box sx={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Box sx={{ textAlign: 'center' }}>
+              <Iconify icon="eva:people-outline" sx={{ width: 64, height: 64, color: 'text.disabled', mb: 2 }} />
+              <Typography variant="h6" color="text.secondary">
+                Select a Creator
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Choose a creator from the left panel to view their V4 submissions
+              </Typography>
+            </Box>
+          </Box>
+        )}
+      </Card>
+    </Box>
+  );
+}
+
+CampaignCreatorSubmissionsV4.propTypes = {
+  campaign: PropTypes.object,
+};

--- a/src/sections/campaign/discover/admin/campaign-detail-creator/campaign-detail-creator.jsx
+++ b/src/sections/campaign/discover/admin/campaign-detail-creator/campaign-detail-creator.jsx
@@ -98,7 +98,7 @@ const CampaignDetailCreator = ({ campaign, campaignMutate }) => {
   const loading = useBoolean();
   const [selectedAgreement, setSelectedAgreement] = useState(null);
   // const [selectedCreators, setSelectedCreators] = useState(null);
-  const ugcVidesoModal = useBoolean();
+  const ugcVideosModal = useBoolean();
   const { addCreators, shortlistedCreators: creators } = useShortlistedCreators();
 
   const totalUsedCredits = campaign?.shortlisted?.reduce(
@@ -398,7 +398,7 @@ const CampaignDetailCreator = ({ campaign, campaignMutate }) => {
               loading={loading.value}
               onClick={() => {
                 if (campaign?.campaignCredits) {
-                  ugcVidesoModal.onTrue();
+                  ugcVideosModal.onTrue();
                 } else {
                   console.log('ASDS');
                 }
@@ -746,8 +746,8 @@ const CampaignDetailCreator = ({ campaign, campaignMutate }) => {
         : renderShortlistFormModalWithoutCampaignCredits}
 
       <AssignUGCVideoModal
-        dialog={ugcVidesoModal.value}
-        onClose={ugcVidesoModal.onFalse}
+        dialog={ugcVideosModal.value}
+        onClose={ugcVideosModal.onFalse}
         credits={campaign?.campaignCredits ?? 0}
         campaignId={campaign.id}
         modalClose={modal.onFalse}

--- a/src/sections/campaign/discover/admin/pitch-modal.jsx
+++ b/src/sections/campaign/discover/admin/pitch-modal.jsx
@@ -149,6 +149,7 @@ const PitchModal = ({ pitch, open, onClose, campaign, onUpdate }) => {
         const v3PitchId = pitch.pitchId || pitch.id; // Use pitchId as it seems to be the correct identifier
         console.log('Using V3 endpoint with pitch ID:', v3PitchId);
         
+        
         // Check user role to call the correct endpoint
         if (user?.role === 'client') {
           // Client approves pitch
@@ -161,7 +162,6 @@ const PitchModal = ({ pitch, open, onClose, campaign, onUpdate }) => {
         }
       } else {
         // Use V2 endpoint for admin-created campaigns
-        // Only send totalUGCVideos for admin-created campaigns, not client-created ones
         const requestData = {
           pitchId: pitch.id,
           status: 'approved',

--- a/src/sections/campaign/discover/admin/submissions/v4/agreement-submission.jsx
+++ b/src/sections/campaign/discover/admin/submissions/v4/agreement-submission.jsx
@@ -1,0 +1,298 @@
+import PropTypes from 'prop-types';
+import { useState, useCallback } from 'react';
+import { enqueueSnackbar } from 'notistack';
+
+import {
+  Box,
+  Card,
+  Chip,
+  Stack,
+  Button,
+  Dialog,
+  TextField,
+  Typography,
+  IconButton,
+  DialogTitle,
+  DialogActions,
+  DialogContent,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+} from '@mui/material';
+
+import Iconify from 'src/components/iconify';
+import { approveV4Submission } from 'src/hooks/use-get-v4-submissions';
+
+// ----------------------------------------------------------------------
+
+export default function V4AgreementSubmission({ submission, campaign, onUpdate }) {
+  const [feedbackDialog, setFeedbackDialog] = useState(false);
+  const [feedback, setFeedback] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [action, setAction] = useState('approve');
+
+  const handleApprove = useCallback(() => {
+    setAction('approve');
+    setFeedback('');
+    setFeedbackDialog(true);
+  }, []);
+
+  const handleReject = useCallback(() => {
+    setAction('reject');
+    setFeedback('');
+    setFeedbackDialog(true);
+  }, []);
+
+  const handleRequestRevision = useCallback(() => {
+    setAction('request_revision');
+    setFeedback('');
+    setFeedbackDialog(true);
+  }, []);
+
+  const handleSubmitFeedback = useCallback(async () => {
+    if (action === 'reject' && !feedback.trim()) {
+      enqueueSnackbar('Please provide feedback for rejection', { variant: 'error' });
+      return;
+    }
+
+    try {
+      setLoading(true);
+      await approveV4Submission({
+        submissionId: submission.id,
+        action,
+        feedback: feedback.trim() || undefined,
+        reasons: [],
+      });
+
+      enqueueSnackbar(
+        `Agreement ${action === 'approve' ? 'approved' : action === 'reject' ? 'rejected' : 'revision requested'} successfully`,
+        { variant: 'success' }
+      );
+      
+      setFeedbackDialog(false);
+      setFeedback('');
+      onUpdate?.();
+    } catch (error) {
+      console.error('Error submitting feedback:', error);
+      enqueueSnackbar(error.message || 'Failed to submit feedback', { variant: 'error' });
+    } finally {
+      setLoading(false);
+    }
+  }, [action, feedback, submission.id, onUpdate]);
+
+  const getStatusColor = (status) => {
+    const statusColors = {
+      PENDING_REVIEW: 'warning',
+      IN_PROGRESS: 'info', 
+      APPROVED: 'success',
+      REJECTED: 'error',
+      CHANGES_REQUIRED: 'warning',
+      SENT_TO_CLIENT: 'primary',
+      CLIENT_APPROVED: 'success',
+      CLIENT_FEEDBACK: 'warning',
+      SENT_TO_ADMIN: 'info',
+    };
+    return statusColors[status] || 'default';
+  };
+
+  const formatStatus = (status) => {
+    return status?.replace(/_/g, ' ').toLowerCase().replace(/\b\w/g, l => l.toUpperCase()) || 'Unknown';
+  };
+
+  return (
+    <>
+      <Accordion>
+        <AccordionSummary expandIcon={<Iconify icon="eva:arrow-ios-downward-fill" />}>
+          <Stack direction="row" alignItems="center" spacing={2} sx={{ width: '100%' }}>
+            <Box sx={{ minWidth: 0, flex: 1 }}>
+              <Stack direction="row" alignItems="center" spacing={2}>
+                <Iconify icon="eva:file-text-fill" sx={{ color: 'info.main' }} />
+                <Typography variant="h6">
+                  Agreement Form
+                </Typography>
+                <Chip
+                  label={formatStatus(submission.status)}
+                  color={getStatusColor(submission.status)}
+                  size="small"
+                />
+              </Stack>
+            </Box>
+          </Stack>
+        </AccordionSummary>
+
+        <AccordionDetails>
+          <Stack spacing={3}>
+            {/* Agreement Content */}
+            <Box>
+              <Typography variant="subtitle2" gutterBottom>
+                Agreement Status
+              </Typography>
+              <Card sx={{ p: 2, bgcolor: 'background.neutral' }}>
+                <Stack spacing={2}>
+                  <Stack direction="row" spacing={2} alignItems="center">
+                    <Chip
+                      label={formatStatus(submission.status)}
+                      color={getStatusColor(submission.status)}
+                      size="small"
+                    />
+                    <Typography variant="body2" color="text.secondary">
+                      {submission.status === 'APPROVED' ? 
+                        'Creator can proceed with content creation' :
+                        submission.status === 'PENDING_REVIEW' ?
+                        'Waiting for admin review' :
+                        'Action required'
+                      }
+                    </Typography>
+                  </Stack>
+
+                  {/* Agreement Details */}
+                  <Box sx={{ pt: 1 }}>
+                    <Typography variant="caption" color="text.secondary">
+                      Agreement submissions are automatically created for V4 campaigns.
+                      Approve this to allow the creator to start working on content submissions.
+                    </Typography>
+                  </Box>
+                </Stack>
+              </Card>
+            </Box>
+
+            {/* Creator Information (if needed) */}
+            <Box>
+              <Typography variant="subtitle2" gutterBottom>
+                Submission Details
+              </Typography>
+              <Card sx={{ p: 2, bgcolor: 'background.neutral' }}>
+                <Stack spacing={1}>
+                  <Typography variant="body2">
+                    <strong>Submission Type:</strong> Agreement Form
+                  </Typography>
+                  <Typography variant="body2">
+                    <strong>Campaign:</strong> {campaign?.name}
+                  </Typography>
+                  <Typography variant="body2">
+                    <strong>Version:</strong> V4 (Content-type based)
+                  </Typography>
+                </Stack>
+              </Card>
+            </Box>
+
+            {/* Admin Actions */}
+            {submission.status === 'PENDING_REVIEW' && (
+              <Stack direction="row" spacing={2}>
+                <Button
+                  variant="contained"
+                  color="success"
+                  onClick={handleApprove}
+                  startIcon={<Iconify icon="eva:checkmark-fill" />}
+                >
+                  Approve Agreement
+                </Button>
+                <Button
+                  variant="outlined"
+                  color="warning"
+                  onClick={handleRequestRevision}
+                  startIcon={<Iconify icon="eva:edit-fill" />}
+                >
+                  Request Changes
+                </Button>
+                <Button
+                  variant="outlined"
+                  color="error"
+                  onClick={handleReject}
+                  startIcon={<Iconify icon="eva:close-fill" />}
+                >
+                  Reject
+                </Button>
+              </Stack>
+            )}
+
+            {/* Status Information */}
+            {submission.status === 'APPROVED' && (
+              <Card sx={{ p: 2, bgcolor: 'success.lighter' }}>
+                <Stack direction="row" alignItems="center" spacing={2}>
+                  <Iconify icon="eva:checkmark-circle-fill" sx={{ color: 'success.main' }} />
+                  <Box>
+                    <Typography variant="subtitle2" color="success.main">
+                      Agreement Approved
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      Creator can now proceed with content submissions (videos, photos, raw footage)
+                    </Typography>
+                  </Box>
+                </Stack>
+              </Card>
+            )}
+
+            {submission.status === 'REJECTED' && (
+              <Card sx={{ p: 2, bgcolor: 'error.lighter' }}>
+                <Stack direction="row" alignItems="center" spacing={2}>
+                  <Iconify icon="eva:close-circle-fill" sx={{ color: 'error.main' }} />
+                  <Box>
+                    <Typography variant="subtitle2" color="error.main">
+                      Agreement Rejected
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      Creator cannot proceed with submissions until agreement is resolved
+                    </Typography>
+                  </Box>
+                </Stack>
+              </Card>
+            )}
+
+            {/* Submission Metadata */}
+            <Box sx={{ pt: 2, borderTop: 1, borderColor: 'divider' }}>
+              <Typography variant="caption" color="text.secondary">
+                Created: {new Date(submission.createdAt).toLocaleString()} •
+                Last updated: {new Date(submission.updatedAt).toLocaleString()}
+              </Typography>
+            </Box>
+          </Stack>
+        </AccordionDetails>
+      </Accordion>
+
+      {/* Feedback Dialog */}
+      <Dialog open={feedbackDialog} onClose={() => setFeedbackDialog(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>
+          {action === 'approve' ? 'Approve Agreement' : 
+           action === 'reject' ? 'Reject Agreement' : 'Request Changes'}
+        </DialogTitle>
+        <DialogContent>
+          <TextField
+            fullWidth
+            multiline
+            rows={4}
+            label={action === 'approve' ? 'Approval message (optional)' : 'Feedback'}
+            value={feedback}
+            onChange={(e) => setFeedback(e.target.value)}
+            placeholder={
+              action === 'approve' ? 'Add any additional comments...' :
+              action === 'reject' ? 'Please explain why this agreement is being rejected...' :
+              'Please specify what changes are needed...'
+            }
+            required={action === 'reject'}
+            sx={{ mt: 1 }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setFeedbackDialog(false)} disabled={loading}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmitFeedback}
+            variant="contained"
+            loading={loading}
+            color={action === 'approve' ? 'success' : action === 'reject' ? 'error' : 'warning'}
+          >
+            {action === 'approve' ? 'Approve' : action === 'reject' ? 'Reject' : 'Request Changes'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}
+
+V4AgreementSubmission.propTypes = {
+  submission: PropTypes.object.isRequired,
+  campaign: PropTypes.object.isRequired,
+  onUpdate: PropTypes.func,
+};

--- a/src/sections/campaign/discover/admin/submissions/v4/photo-submission.jsx
+++ b/src/sections/campaign/discover/admin/submissions/v4/photo-submission.jsx
@@ -1,0 +1,403 @@
+import PropTypes from 'prop-types';
+import { useState, useCallback } from 'react';
+import { enqueueSnackbar } from 'notistack';
+
+import {
+  Box,
+  Card,
+  Chip,
+  Grid,
+  Stack,
+  Button,
+  Dialog,
+  TextField,
+  Typography,
+  IconButton,
+  DialogTitle,
+  DialogActions,
+  DialogContent,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+} from '@mui/material';
+
+import Iconify from 'src/components/iconify';
+import { approveV4Submission, updateV4PostingLink } from 'src/hooks/use-get-v4-submissions';
+
+// ----------------------------------------------------------------------
+
+export default function V4PhotoSubmission({ submission, campaign, index = 1, onUpdate }) {
+  const [feedbackDialog, setFeedbackDialog] = useState(false);
+  const [postingDialog, setPostingDialog] = useState(false);
+  const [feedback, setFeedback] = useState('');
+  const [postingLink, setPostingLink] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [action, setAction] = useState('approve');
+
+  const photos = submission.photos || []; // V4 can have multiple photos
+  const isApproved = submission.status === 'APPROVED';
+  const hasPostingLink = Boolean(submission.content);
+
+  const handleApprove = useCallback(() => {
+    setAction('approve');
+    setFeedback('');
+    setFeedbackDialog(true);
+  }, []);
+
+  const handleReject = useCallback(() => {
+    setAction('reject');
+    setFeedback('');
+    setFeedbackDialog(true);
+  }, []);
+
+  const handleRequestRevision = useCallback(() => {
+    setAction('request_revision');
+    setFeedback('');
+    setFeedbackDialog(true);
+  }, []);
+
+  const handleSubmitFeedback = useCallback(async () => {
+    if (action === 'reject' && !feedback.trim()) {
+      enqueueSnackbar('Please provide feedback for rejection', { variant: 'error' });
+      return;
+    }
+
+    try {
+      setLoading(true);
+      await approveV4Submission({
+        submissionId: submission.id,
+        action,
+        feedback: feedback.trim() || undefined,
+        reasons: [],
+      });
+
+      enqueueSnackbar(
+        `Photos ${action === 'approve' ? 'approved' : action === 'reject' ? 'rejected' : 'revision requested'} successfully`,
+        { variant: 'success' }
+      );
+      
+      setFeedbackDialog(false);
+      setFeedback('');
+      onUpdate?.();
+    } catch (error) {
+      console.error('Error submitting feedback:', error);
+      enqueueSnackbar(error.message || 'Failed to submit feedback', { variant: 'error' });
+    } finally {
+      setLoading(false);
+    }
+  }, [action, feedback, submission.id, onUpdate]);
+
+  const handleAddPostingLink = useCallback(() => {
+    setPostingLink(submission.content || '');
+    setPostingDialog(true);
+  }, [submission.content]);
+
+  const handleSubmitPostingLink = useCallback(async () => {
+    if (!postingLink.trim()) {
+      enqueueSnackbar('Please enter a posting link', { variant: 'error' });
+      return;
+    }
+
+    try {
+      setLoading(true);
+      await updateV4PostingLink({
+        submissionId: submission.id,
+        postingLink: postingLink.trim(),
+      });
+
+      enqueueSnackbar('Posting link updated successfully', { variant: 'success' });
+      setPostingDialog(false);
+      onUpdate?.();
+    } catch (error) {
+      console.error('Error updating posting link:', error);
+      enqueueSnackbar(error.message || 'Failed to update posting link', { variant: 'error' });
+    } finally {
+      setLoading(false);
+    }
+  }, [postingLink, submission.id, onUpdate]);
+
+  const getStatusColor = (status) => {
+    const statusColors = {
+      PENDING_REVIEW: 'warning',
+      IN_PROGRESS: 'info', 
+      APPROVED: 'success',
+      REJECTED: 'error',
+      CHANGES_REQUIRED: 'warning',
+      SENT_TO_CLIENT: 'primary',
+      CLIENT_APPROVED: 'success',
+      CLIENT_FEEDBACK: 'warning',
+      SENT_TO_ADMIN: 'info',
+    };
+    return statusColors[status] || 'default';
+  };
+
+  const formatStatus = (status) => {
+    return status?.replace(/_/g, ' ').toLowerCase().replace(/\b\w/g, l => l.toUpperCase()) || 'Unknown';
+  };
+
+  return (
+    <>
+      <Accordion>
+        <AccordionSummary expandIcon={<Iconify icon="eva:arrow-ios-downward-fill" />}>
+          <Stack direction="row" alignItems="center" spacing={2} sx={{ width: '100%' }}>
+            <Box sx={{ minWidth: 0, flex: 1 }}>
+              <Stack direction="row" alignItems="center" spacing={2}>
+                <Iconify icon="eva:image-fill" sx={{ color: 'secondary.main' }} />
+                <Typography variant="h6">
+                  Photo Submission {index}
+                </Typography>
+                <Chip
+                  label={formatStatus(submission.status)}
+                  color={getStatusColor(submission.status)}
+                  size="small"
+                />
+                {hasPostingLink && (
+                  <Chip
+                    icon={<Iconify icon="eva:link-2-fill" />}
+                    label="Has Posting Link"
+                    color="info"
+                    variant="outlined"
+                    size="small"
+                  />
+                )}
+                {photos.length > 0 && (
+                  <Chip
+                    label={`${photos.length} photo${photos.length > 1 ? 's' : ''}`}
+                    variant="outlined"
+                    size="small"
+                  />
+                )}
+              </Stack>
+            </Box>
+          </Stack>
+        </AccordionSummary>
+
+        <AccordionDetails>
+          <Stack spacing={3}>
+            {/* Photo Content */}
+            <Box>
+              <Typography variant="subtitle2" gutterBottom>
+                Photo Content ({photos.length} photos)
+              </Typography>
+              {photos.length > 0 ? (
+                <Grid container spacing={2}>
+                  {photos.map((photo, photoIndex) => (
+                    <Grid item xs={12} sm={6} md={4} key={photo.id}>
+                      <Card sx={{ overflow: 'hidden' }}>
+                        <Box
+                          component="img"
+                          src={photo.url}
+                          alt={`Photo ${photoIndex + 1}`}
+                          sx={{
+                            width: '100%',
+                            height: 200,
+                            objectFit: 'cover',
+                          }}
+                        />
+                        <Box sx={{ p: 1 }}>
+                          <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between">
+                            <Chip
+                              label={formatStatus(photo.status)}
+                              color={getStatusColor(photo.status)}
+                              size="small"
+                            />
+                            {photo.feedback && (
+                              <Typography variant="caption" color="text.secondary">
+                                Has feedback
+                              </Typography>
+                            )}
+                          </Stack>
+                          
+                          {photo.feedback && (
+                            <Box sx={{ mt: 1 }}>
+                              <Typography variant="caption" fontWeight="medium">
+                                Feedback:
+                              </Typography>
+                              <Typography variant="caption" display="block" sx={{ mt: 0.5 }}>
+                                {photo.feedback}
+                              </Typography>
+                            </Box>
+                          )}
+                        </Box>
+                      </Card>
+                    </Grid>
+                  ))}
+                </Grid>
+              ) : (
+                <Card sx={{ p: 2, bgcolor: 'background.neutral' }}>
+                  <Typography color="text.secondary">No photos uploaded yet</Typography>
+                </Card>
+              )}
+            </Box>
+
+            {/* Caption */}
+            {submission.caption && (
+              <Box>
+                <Typography variant="subtitle2" gutterBottom>
+                  Caption
+                </Typography>
+                <Card sx={{ p: 2, bgcolor: 'background.neutral' }}>
+                  <Typography variant="body2">{submission.caption}</Typography>
+                </Card>
+              </Box>
+            )}
+
+            {/* Posting Link */}
+            <Box>
+              <Stack direction="row" alignItems="center" justifyContent="space-between">
+                <Typography variant="subtitle2">
+                  Posting Link
+                </Typography>
+                {isApproved && (
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    onClick={handleAddPostingLink}
+                    startIcon={<Iconify icon="eva:link-2-fill" />}
+                  >
+                    {hasPostingLink ? 'Update Link' : 'Add Link'}
+                  </Button>
+                )}
+              </Stack>
+              
+              <Card sx={{ p: 2, bgcolor: 'background.neutral', mt: 1 }}>
+                {hasPostingLink ? (
+                  <Stack direction="row" alignItems="center" spacing={2}>
+                    <Typography variant="body2" sx={{ flex: 1, wordBreak: 'break-all' }}>
+                      {submission.content}
+                    </Typography>
+                    <IconButton
+                      size="small"
+                      onClick={() => window.open(submission.content, '_blank')}
+                    >
+                      <Iconify icon="eva:external-link-fill" />
+                    </IconButton>
+                  </Stack>
+                ) : (
+                  <Typography color="text.secondary">
+                    {isApproved ? 'Creator can add posting link after approval' : 'Available after approval'}
+                  </Typography>
+                )}
+              </Card>
+            </Box>
+
+            {/* Admin Actions */}
+            {submission.status === 'PENDING_REVIEW' && (
+              <Stack direction="row" spacing={2}>
+                <Button
+                  variant="contained"
+                  color="success"
+                  onClick={handleApprove}
+                  startIcon={<Iconify icon="eva:checkmark-fill" />}
+                >
+                  Approve
+                </Button>
+                <Button
+                  variant="outlined"
+                  color="warning"
+                  onClick={handleRequestRevision}
+                  startIcon={<Iconify icon="eva:edit-fill" />}
+                >
+                  Request Changes
+                </Button>
+                <Button
+                  variant="outlined"
+                  color="error"
+                  onClick={handleReject}
+                  startIcon={<Iconify icon="eva:close-fill" />}
+                >
+                  Reject
+                </Button>
+              </Stack>
+            )}
+
+            {/* Submission Metadata */}
+            <Box sx={{ pt: 2, borderTop: 1, borderColor: 'divider' }}>
+              <Typography variant="caption" color="text.secondary">
+                Created: {new Date(submission.createdAt).toLocaleString()} •
+                Last updated: {new Date(submission.updatedAt).toLocaleString()}
+              </Typography>
+            </Box>
+          </Stack>
+        </AccordionDetails>
+      </Accordion>
+
+      {/* Feedback Dialog */}
+      <Dialog open={feedbackDialog} onClose={() => setFeedbackDialog(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>
+          {action === 'approve' ? 'Approve Photos' : 
+           action === 'reject' ? 'Reject Photos' : 'Request Changes'}
+        </DialogTitle>
+        <DialogContent>
+          <TextField
+            fullWidth
+            multiline
+            rows={4}
+            label={action === 'approve' ? 'Approval message (optional)' : 'Feedback'}
+            value={feedback}
+            onChange={(e) => setFeedback(e.target.value)}
+            placeholder={
+              action === 'approve' ? 'Add any additional comments...' :
+              action === 'reject' ? 'Please explain why these photos are being rejected...' :
+              'Please specify what changes are needed...'
+            }
+            required={action === 'reject'}
+            sx={{ mt: 1 }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setFeedbackDialog(false)} disabled={loading}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmitFeedback}
+            variant="contained"
+            loading={loading}
+            color={action === 'approve' ? 'success' : action === 'reject' ? 'error' : 'warning'}
+          >
+            {action === 'approve' ? 'Approve' : action === 'reject' ? 'Reject' : 'Request Changes'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Posting Link Dialog */}
+      <Dialog open={postingDialog} onClose={() => setPostingDialog(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>
+          {hasPostingLink ? 'Update Posting Link' : 'Add Posting Link'}
+        </DialogTitle>
+        <DialogContent>
+          <TextField
+            fullWidth
+            label="Posting URL"
+            value={postingLink}
+            onChange={(e) => setPostingLink(e.target.value)}
+            placeholder="https://www.instagram.com/p/ABC123/"
+            sx={{ mt: 1 }}
+          />
+          <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
+            Enter the social media post URL where these photos were published
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setPostingDialog(false)} disabled={loading}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmitPostingLink}
+            variant="contained"
+            loading={loading}
+          >
+            {hasPostingLink ? 'Update' : 'Add'} Link
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}
+
+V4PhotoSubmission.propTypes = {
+  submission: PropTypes.object.isRequired,
+  campaign: PropTypes.object.isRequired,
+  index: PropTypes.number,
+  onUpdate: PropTypes.func,
+};

--- a/src/sections/campaign/discover/admin/submissions/v4/raw-footage-submission.jsx
+++ b/src/sections/campaign/discover/admin/submissions/v4/raw-footage-submission.jsx
@@ -1,0 +1,276 @@
+import PropTypes from 'prop-types';
+import { useState, useCallback } from 'react';
+import { enqueueSnackbar } from 'notistack';
+
+import {
+  Box,
+  Card,
+  Chip,
+  Stack,
+  Button,
+  Dialog,
+  TextField,
+  Typography,
+  DialogTitle,
+  DialogActions,
+  DialogContent,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+} from '@mui/material';
+
+import Iconify from 'src/components/iconify';
+import { approveV4Submission } from 'src/hooks/use-get-v4-submissions';
+
+// ----------------------------------------------------------------------
+
+export default function V4RawFootageSubmission({ submission, campaign, index = 1, onUpdate }) {
+  const [feedbackDialog, setFeedbackDialog] = useState(false);
+  const [feedback, setFeedback] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [action, setAction] = useState('approve');
+
+  const rawFootage = submission.rawFootages?.[0]; // V4 has one raw footage per submission
+
+  const handleApprove = useCallback(() => {
+    setAction('approve');
+    setFeedback('');
+    setFeedbackDialog(true);
+  }, []);
+
+  const handleReject = useCallback(() => {
+    setAction('reject');
+    setFeedback('');
+    setFeedbackDialog(true);
+  }, []);
+
+  const handleRequestRevision = useCallback(() => {
+    setAction('request_revision');
+    setFeedback('');
+    setFeedbackDialog(true);
+  }, []);
+
+  const handleSubmitFeedback = useCallback(async () => {
+    if (action === 'reject' && !feedback.trim()) {
+      enqueueSnackbar('Please provide feedback for rejection', { variant: 'error' });
+      return;
+    }
+
+    try {
+      setLoading(true);
+      await approveV4Submission({
+        submissionId: submission.id,
+        action,
+        feedback: feedback.trim() || undefined,
+        reasons: [],
+      });
+
+      enqueueSnackbar(
+        `Raw footage ${action === 'approve' ? 'approved' : action === 'reject' ? 'rejected' : 'revision requested'} successfully`,
+        { variant: 'success' }
+      );
+      
+      setFeedbackDialog(false);
+      setFeedback('');
+      onUpdate?.();
+    } catch (error) {
+      console.error('Error submitting feedback:', error);
+      enqueueSnackbar(error.message || 'Failed to submit feedback', { variant: 'error' });
+    } finally {
+      setLoading(false);
+    }
+  }, [action, feedback, submission.id, onUpdate]);
+
+  const getStatusColor = (status) => {
+    const statusColors = {
+      PENDING_REVIEW: 'warning',
+      IN_PROGRESS: 'info', 
+      APPROVED: 'success',
+      REJECTED: 'error',
+      CHANGES_REQUIRED: 'warning',
+      SENT_TO_CLIENT: 'primary',
+      CLIENT_APPROVED: 'success',
+      CLIENT_FEEDBACK: 'warning',
+      SENT_TO_ADMIN: 'info',
+    };
+    return statusColors[status] || 'default';
+  };
+
+  const formatStatus = (status) => {
+    return status?.replace(/_/g, ' ').toLowerCase().replace(/\b\w/g, l => l.toUpperCase()) || 'Unknown';
+  };
+
+  return (
+    <>
+      <Accordion>
+        <AccordionSummary expandIcon={<Iconify icon="eva:arrow-ios-downward-fill" />}>
+          <Stack direction="row" alignItems="center" spacing={2} sx={{ width: '100%' }}>
+            <Box sx={{ minWidth: 0, flex: 1 }}>
+              <Stack direction="row" alignItems="center" spacing={2}>
+                <Iconify icon="eva:film-fill" sx={{ color: 'warning.main' }} />
+                <Typography variant="h6">
+                  Raw Footage {index}
+                </Typography>
+                <Chip
+                  label={formatStatus(submission.status)}
+                  color={getStatusColor(submission.status)}
+                  size="small"
+                />
+              </Stack>
+            </Box>
+          </Stack>
+        </AccordionSummary>
+
+        <AccordionDetails>
+          <Stack spacing={3}>
+            {/* Raw Footage Content */}
+            <Box>
+              <Typography variant="subtitle2" gutterBottom>
+                Raw Footage Content
+              </Typography>
+              {rawFootage ? (
+                <Card sx={{ p: 2, bgcolor: 'background.neutral' }}>
+                  <Stack spacing={2}>
+                    {rawFootage.url ? (
+                      <Box>
+                        <video
+                          controls
+                          style={{ width: '100%', maxWidth: 400, height: 'auto' }}
+                          src={rawFootage.url}
+                        />
+                      </Box>
+                    ) : (
+                      <Typography color="text.secondary">No raw footage uploaded yet</Typography>
+                    )}
+                    
+                    <Stack direction="row" spacing={2} alignItems="center">
+                      <Chip
+                        label={formatStatus(rawFootage.status)}
+                        color={getStatusColor(rawFootage.status)}
+                        size="small"
+                      />
+                      {rawFootage.feedback && (
+                        <Typography variant="caption" color="text.secondary">
+                          Last feedback: {new Date(rawFootage.feedbackAt).toLocaleDateString()}
+                        </Typography>
+                      )}
+                    </Stack>
+
+                    {rawFootage.feedback && (
+                      <Box sx={{ mt: 1 }}>
+                        <Typography variant="caption" fontWeight="medium">
+                          Feedback:
+                        </Typography>
+                        <Typography variant="body2" sx={{ mt: 0.5 }}>
+                          {rawFootage.feedback}
+                        </Typography>
+                      </Box>
+                    )}
+                  </Stack>
+                </Card>
+              ) : (
+                <Typography color="text.secondary">No raw footage data available</Typography>
+              )}
+            </Box>
+
+            {/* Caption */}
+            {submission.caption && (
+              <Box>
+                <Typography variant="subtitle2" gutterBottom>
+                  Caption
+                </Typography>
+                <Card sx={{ p: 2, bgcolor: 'background.neutral' }}>
+                  <Typography variant="body2">{submission.caption}</Typography>
+                </Card>
+              </Box>
+            )}
+
+            {/* Admin Actions */}
+            {submission.status === 'PENDING_REVIEW' && (
+              <Stack direction="row" spacing={2}>
+                <Button
+                  variant="contained"
+                  color="success"
+                  onClick={handleApprove}
+                  startIcon={<Iconify icon="eva:checkmark-fill" />}
+                >
+                  Approve
+                </Button>
+                <Button
+                  variant="outlined"
+                  color="warning"
+                  onClick={handleRequestRevision}
+                  startIcon={<Iconify icon="eva:edit-fill" />}
+                >
+                  Request Changes
+                </Button>
+                <Button
+                  variant="outlined"
+                  color="error"
+                  onClick={handleReject}
+                  startIcon={<Iconify icon="eva:close-fill" />}
+                >
+                  Reject
+                </Button>
+              </Stack>
+            )}
+
+            {/* Submission Metadata */}
+            <Box sx={{ pt: 2, borderTop: 1, borderColor: 'divider' }}>
+              <Typography variant="caption" color="text.secondary">
+                Created: {new Date(submission.createdAt).toLocaleString()} •
+                Last updated: {new Date(submission.updatedAt).toLocaleString()}
+              </Typography>
+            </Box>
+          </Stack>
+        </AccordionDetails>
+      </Accordion>
+
+      {/* Feedback Dialog */}
+      <Dialog open={feedbackDialog} onClose={() => setFeedbackDialog(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>
+          {action === 'approve' ? 'Approve Raw Footage' : 
+           action === 'reject' ? 'Reject Raw Footage' : 'Request Changes'}
+        </DialogTitle>
+        <DialogContent>
+          <TextField
+            fullWidth
+            multiline
+            rows={4}
+            label={action === 'approve' ? 'Approval message (optional)' : 'Feedback'}
+            value={feedback}
+            onChange={(e) => setFeedback(e.target.value)}
+            placeholder={
+              action === 'approve' ? 'Add any additional comments...' :
+              action === 'reject' ? 'Please explain why this raw footage is being rejected...' :
+              'Please specify what changes are needed...'
+            }
+            required={action === 'reject'}
+            sx={{ mt: 1 }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setFeedbackDialog(false)} disabled={loading}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmitFeedback}
+            variant="contained"
+            loading={loading}
+            color={action === 'approve' ? 'success' : action === 'reject' ? 'error' : 'warning'}
+          >
+            {action === 'approve' ? 'Approve' : action === 'reject' ? 'Reject' : 'Request Changes'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+    </>
+  );
+}
+
+V4RawFootageSubmission.propTypes = {
+  submission: PropTypes.object.isRequired,
+  campaign: PropTypes.object.isRequired,
+  index: PropTypes.number,
+  onUpdate: PropTypes.func,
+};

--- a/src/sections/campaign/discover/admin/submissions/v4/video-submission.jsx
+++ b/src/sections/campaign/discover/admin/submissions/v4/video-submission.jsx
@@ -1,0 +1,389 @@
+import PropTypes from 'prop-types';
+import { useState, useCallback } from 'react';
+import { enqueueSnackbar } from 'notistack';
+
+import {
+  Box,
+  Card,
+  Chip,
+  Stack,
+  Button,
+  Dialog,
+  TextField,
+  Typography,
+  IconButton,
+  DialogTitle,
+  DialogActions,
+  DialogContent,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+} from '@mui/material';
+
+import Iconify from 'src/components/iconify';
+import { approveV4Submission, updateV4PostingLink } from 'src/hooks/use-get-v4-submissions';
+
+// ----------------------------------------------------------------------
+
+export default function V4VideoSubmission({ submission, campaign, index = 1, onUpdate }) {
+  const [feedbackDialog, setFeedbackDialog] = useState(false);
+  const [postingDialog, setPostingDialog] = useState(false);
+  const [feedback, setFeedback] = useState('');
+  const [postingLink, setPostingLink] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [action, setAction] = useState('approve');
+
+  const video = submission.video?.[0]; // V4 has one video per submission
+  const isApproved = submission.status === 'APPROVED';
+  const hasPostingLink = Boolean(submission.content);
+
+  const handleApprove = useCallback(() => {
+    setAction('approve');
+    setFeedback('');
+    setFeedbackDialog(true);
+  }, []);
+
+  const handleReject = useCallback(() => {
+    setAction('reject');
+    setFeedback('');
+    setFeedbackDialog(true);
+  }, []);
+
+  const handleRequestRevision = useCallback(() => {
+    setAction('request_revision');
+    setFeedback('');
+    setFeedbackDialog(true);
+  }, []);
+
+  const handleSubmitFeedback = useCallback(async () => {
+    if (action === 'reject' && !feedback.trim()) {
+      enqueueSnackbar('Please provide feedback for rejection', { variant: 'error' });
+      return;
+    }
+
+    try {
+      setLoading(true);
+      await approveV4Submission({
+        submissionId: submission.id,
+        action,
+        feedback: feedback.trim() || undefined,
+        reasons: [], // Could add reasons selection later
+      });
+
+      enqueueSnackbar(
+        `Video ${action === 'approve' ? 'approved' : action === 'reject' ? 'rejected' : 'revision requested'} successfully`,
+        { variant: 'success' }
+      );
+      
+      setFeedbackDialog(false);
+      setFeedback('');
+      onUpdate?.();
+    } catch (error) {
+      console.error('Error submitting feedback:', error);
+      enqueueSnackbar(error.message || 'Failed to submit feedback', { variant: 'error' });
+    } finally {
+      setLoading(false);
+    }
+  }, [action, feedback, submission.id, onUpdate]);
+
+  const handleAddPostingLink = useCallback(() => {
+    setPostingLink(submission.content || '');
+    setPostingDialog(true);
+  }, [submission.content]);
+
+  const handleSubmitPostingLink = useCallback(async () => {
+    if (!postingLink.trim()) {
+      enqueueSnackbar('Please enter a posting link', { variant: 'error' });
+      return;
+    }
+
+    try {
+      setLoading(true);
+      await updateV4PostingLink({
+        submissionId: submission.id,
+        postingLink: postingLink.trim(),
+      });
+
+      enqueueSnackbar('Posting link updated successfully', { variant: 'success' });
+      setPostingDialog(false);
+      onUpdate?.();
+    } catch (error) {
+      console.error('Error updating posting link:', error);
+      enqueueSnackbar(error.message || 'Failed to update posting link', { variant: 'error' });
+    } finally {
+      setLoading(false);
+    }
+  }, [postingLink, submission.id, onUpdate]);
+
+  const getStatusColor = (status) => {
+    const statusColors = {
+      PENDING_REVIEW: 'warning',
+      IN_PROGRESS: 'info', 
+      APPROVED: 'success',
+      REJECTED: 'error',
+      CHANGES_REQUIRED: 'warning',
+      SENT_TO_CLIENT: 'primary',
+      CLIENT_APPROVED: 'success',
+      CLIENT_FEEDBACK: 'warning',
+      SENT_TO_ADMIN: 'info',
+    };
+    return statusColors[status] || 'default';
+  };
+
+  const formatStatus = (status) => {
+    return status?.replace(/_/g, ' ').toLowerCase().replace(/\b\w/g, l => l.toUpperCase()) || 'Unknown';
+  };
+
+  return (
+    <>
+      <Accordion>
+        <AccordionSummary expandIcon={<Iconify icon="eva:arrow-ios-downward-fill" />}>
+          <Stack direction="row" alignItems="center" spacing={2} sx={{ width: '100%' }}>
+            <Box sx={{ minWidth: 0, flex: 1 }}>
+              <Stack direction="row" alignItems="center" spacing={2}>
+                <Iconify icon="eva:video-fill" sx={{ color: 'primary.main' }} />
+                <Typography variant="h6">
+                  Video {index}
+                </Typography>
+                <Chip
+                  label={formatStatus(submission.status)}
+                  color={getStatusColor(submission.status)}
+                  size="small"
+                />
+                {hasPostingLink && (
+                  <Chip
+                    icon={<Iconify icon="eva:link-2-fill" />}
+                    label="Has Posting Link"
+                    color="info"
+                    variant="outlined"
+                    size="small"
+                  />
+                )}
+              </Stack>
+            </Box>
+          </Stack>
+        </AccordionSummary>
+
+        <AccordionDetails>
+          <Stack spacing={3}>
+            {/* Video Content */}
+            <Box>
+              <Typography variant="subtitle2" gutterBottom>
+                Video Content
+              </Typography>
+              {video ? (
+                <Card sx={{ p: 2, bgcolor: 'background.neutral' }}>
+                  <Stack spacing={2}>
+                    {video.url ? (
+                      <Box>
+                        <video
+                          controls
+                          style={{ width: '100%', maxWidth: 400, height: 'auto' }}
+                          src={video.url}
+                        />
+                      </Box>
+                    ) : (
+                      <Typography color="text.secondary">No video uploaded yet</Typography>
+                    )}
+                    
+                    <Stack direction="row" spacing={2} alignItems="center">
+                      <Chip
+                        label={formatStatus(video.status)}
+                        color={getStatusColor(video.status)}
+                        size="small"
+                      />
+                      {video.feedback && (
+                        <Typography variant="caption" color="text.secondary">
+                          Last feedback: {new Date(video.feedbackAt).toLocaleDateString()}
+                        </Typography>
+                      )}
+                    </Stack>
+
+                    {video.feedback && (
+                      <Box sx={{ mt: 1 }}>
+                        <Typography variant="caption" fontWeight="medium">
+                          Feedback:
+                        </Typography>
+                        <Typography variant="body2" sx={{ mt: 0.5 }}>
+                          {video.feedback}
+                        </Typography>
+                      </Box>
+                    )}
+                  </Stack>
+                </Card>
+              ) : (
+                <Typography color="text.secondary">No video data available</Typography>
+              )}
+            </Box>
+
+            {/* Caption */}
+            {submission.caption && (
+              <Box>
+                <Typography variant="subtitle2" gutterBottom>
+                  Caption
+                </Typography>
+                <Card sx={{ p: 2, bgcolor: 'background.neutral' }}>
+                  <Typography variant="body2">{submission.caption}</Typography>
+                </Card>
+              </Box>
+            )}
+
+            {/* Posting Link */}
+            <Box>
+              <Stack direction="row" alignItems="center" justifyContent="space-between">
+                <Typography variant="subtitle2">
+                  Posting Link
+                </Typography>
+                {isApproved && (
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    onClick={handleAddPostingLink}
+                    startIcon={<Iconify icon="eva:link-2-fill" />}
+                  >
+                    {hasPostingLink ? 'Update Link' : 'Add Link'}
+                  </Button>
+                )}
+              </Stack>
+              
+              <Card sx={{ p: 2, bgcolor: 'background.neutral', mt: 1 }}>
+                {hasPostingLink ? (
+                  <Stack direction="row" alignItems="center" spacing={2}>
+                    <Typography variant="body2" sx={{ flex: 1, wordBreak: 'break-all' }}>
+                      {submission.content}
+                    </Typography>
+                    <IconButton
+                      size="small"
+                      onClick={() => window.open(submission.content, '_blank')}
+                    >
+                      <Iconify icon="eva:external-link-fill" />
+                    </IconButton>
+                  </Stack>
+                ) : (
+                  <Typography color="text.secondary">
+                    {isApproved ? 'Creator can add posting link after approval' : 'Available after approval'}
+                  </Typography>
+                )}
+              </Card>
+            </Box>
+
+            {/* Admin Actions */}
+            {submission.status === 'PENDING_REVIEW' && (
+              <Stack direction="row" spacing={2}>
+                <Button
+                  variant="contained"
+                  color="success"
+                  onClick={handleApprove}
+                  startIcon={<Iconify icon="eva:checkmark-fill" />}
+                >
+                  Approve
+                </Button>
+                <Button
+                  variant="outlined"
+                  color="warning"
+                  onClick={handleRequestRevision}
+                  startIcon={<Iconify icon="eva:edit-fill" />}
+                >
+                  Request Changes
+                </Button>
+                <Button
+                  variant="outlined"
+                  color="error"
+                  onClick={handleReject}
+                  startIcon={<Iconify icon="eva:close-fill" />}
+                >
+                  Reject
+                </Button>
+              </Stack>
+            )}
+
+            {/* Submission Metadata */}
+            <Box sx={{ pt: 2, borderTop: 1, borderColor: 'divider' }}>
+              <Typography variant="caption" color="text.secondary">
+                Created: {new Date(submission.createdAt).toLocaleString()} •
+                Last updated: {new Date(submission.updatedAt).toLocaleString()}
+              </Typography>
+            </Box>
+          </Stack>
+        </AccordionDetails>
+      </Accordion>
+
+      {/* Feedback Dialog */}
+      <Dialog open={feedbackDialog} onClose={() => setFeedbackDialog(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>
+          {action === 'approve' ? 'Approve Video' : 
+           action === 'reject' ? 'Reject Video' : 'Request Changes'}
+        </DialogTitle>
+        <DialogContent>
+          <TextField
+            fullWidth
+            multiline
+            rows={4}
+            label={action === 'approve' ? 'Approval message (optional)' : 'Feedback'}
+            value={feedback}
+            onChange={(e) => setFeedback(e.target.value)}
+            placeholder={
+              action === 'approve' ? 'Add any additional comments...' :
+              action === 'reject' ? 'Please explain why this video is being rejected...' :
+              'Please specify what changes are needed...'
+            }
+            required={action === 'reject'}
+            sx={{ mt: 1 }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setFeedbackDialog(false)} disabled={loading}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmitFeedback}
+            variant="contained"
+            loading={loading}
+            color={action === 'approve' ? 'success' : action === 'reject' ? 'error' : 'warning'}
+          >
+            {action === 'approve' ? 'Approve' : action === 'reject' ? 'Reject' : 'Request Changes'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Posting Link Dialog */}
+      <Dialog open={postingDialog} onClose={() => setPostingDialog(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>
+          {hasPostingLink ? 'Update Posting Link' : 'Add Posting Link'}
+        </DialogTitle>
+        <DialogContent>
+          <TextField
+            fullWidth
+            label="Posting URL"
+            value={postingLink}
+            onChange={(e) => setPostingLink(e.target.value)}
+            placeholder="https://www.tiktok.com/@username/video/123456789"
+            sx={{ mt: 1 }}
+          />
+          <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
+            Enter the social media post URL where this video was published
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setPostingDialog(false)} disabled={loading}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmitPostingLink}
+            variant="contained"
+            loading={loading}
+          >
+            {hasPostingLink ? 'Update' : 'Add'} Link
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}
+
+V4VideoSubmission.propTypes = {
+  submission: PropTypes.object.isRequired,
+  campaign: PropTypes.object.isRequired,
+  index: PropTypes.number,
+  onUpdate: PropTypes.func,
+};

--- a/src/sections/campaign/discover/admin/view/campaign-detail-view.jsx
+++ b/src/sections/campaign/discover/admin/view/campaign-detail-view.jsx
@@ -67,6 +67,7 @@ import CampaignV3PitchesWrapper from '../../client/v3-pitches/campaign-v3-pitche
 import CampaignCreatorMasterListClient from '../campaign-creator-master-list-client';
 import CampaignDetailCreator from '../campaign-detail-creator/campaign-detail-creator';
 import CampaignCreatorDeliverablesClient from '../campaign-creator-deliverables-client';
+import CampaignCreatorSubmissionsV4 from '../campaign-creator-submissions-v4';
 
 // Ensure campaignTabs exists and is loaded from localStorage
 if (typeof window !== 'undefined') {
@@ -86,6 +87,7 @@ const clientAllowedTabs = [
   'campaign-content',
   'creator-master-list',
   'deliverables',
+  'submissions-v4',
   'analytics',
 ];
 
@@ -291,6 +293,7 @@ const CampaignDetailView = ({ id }) => {
                 { label: 'Campaign Details', value: 'campaign-content' },
                 { label: 'Creator Master List', value: 'creator-master-list' },
                 { label: 'Creator Deliverables', value: 'deliverables' },
+                { label: 'Creator Submissions (V4)', value: 'submissions-v4' },
                 { label: 'Campaign Analytics', value: 'analytics' },
               ]
             : // Admin/other user tabs
@@ -321,6 +324,10 @@ const CampaignDetailView = ({ id }) => {
                 {
                   label: 'Creator Deliverables',
                   value: 'deliverables',
+                },
+                {
+                  label: 'Creator Submissions (V4)',
+                  value: 'submissions-v4',
                 },
                 {
                   label: 'Campaign Analytics',
@@ -485,6 +492,7 @@ const CampaignDetailView = ({ id }) => {
     ) : (
       <CampaignCreatorDeliverables campaign={campaign} />
     ),
+    'submissions-v4': <CampaignCreatorSubmissionsV4 campaign={campaign} />,
     analytics: <CampaignAnalytics campaign={campaign} campaignMutate={campaignMutate} />,
   };
 

--- a/src/utils/axios.js
+++ b/src/utils/axios.js
@@ -289,6 +289,15 @@ export const endpoints = {
         forwardFeedback: '/api/submission/v3/posting/forward-feedback',
       },
     },
+    // V4 endpoints for content-type based submissions
+    v4: {
+      create: '/api/submissions/v4/create',
+      getSubmissions: '/api/submissions/v4/submissions',
+      getById: '/api/submissions/v4/submission',
+      submitContent: '/api/submissions/v4/submit-content',
+      approve: '/api/submissions/v4/approve',
+      postingLink: '/api/submissions/v4/posting-link',
+    },
     creator: {
       agreement: '/api/submission/submitAgreement',
       draftSubmission: '/api/submission/draftSubmission',


### PR DESCRIPTION
## Problem
Admins couldn't see creator signatures in uploaded agreements because the view was conditionally showing different PDF sources based on approval status.

## Solution
Modified the iframe source to always prioritize the submitted agreement content `(agreement?.submission?.content)` over the original unsigned agreement URL.

## Changed
- `campaign-agreements.jsx`: Updated PDF source logic to show signed version when available

Impact: Admins can now properly review signed agreements regardless of approval status, ensuring signatures are visible during the entire review process.