### PR TITLE
CCB-402 Fix: Missing creator signatures

### DIFF
--- a/src/sections/campaign/discover/admin/campaign-agreements.jsx
+++ b/src/sections/campaign/discover/admin/campaign-agreements.jsx
@@ -229,11 +229,7 @@ const AgreementDialog = ({ open, onClose, url, agreement, campaign, onApprove, o
         </DialogTitle>
         <DialogContent>
           <iframe
-            src={
-              isPendingReview && agreement?.submission?.content
-                ? agreement?.submission?.content
-                : url
-            }
+            src={agreement?.submission?.content || url}
             title="Agreement"
             style={{ width: '100%', height: '600px', border: 'none' }}
           />


### PR DESCRIPTION
## Problem
Admins couldn't see creator signatures in uploaded agreements because the view was conditionally showing different PDF sources based on approval status.

## Solution
Modified the iframe source to always prioritize the submitted agreement content (`agreement?.submission?.content`) over the original unsigned agreement URL.