### PR TITLE
CCB-536 Fix: Admin posting link submission payload

### DIFF
--- a/src/sections/campaign/discover/admin/creator-stuff/submissions/posting/posting.jsx
+++ b/src/sections/campaign/discover/admin/creator-stuff/submissions/posting/posting.jsx
@@ -137,7 +137,7 @@ const Posting = ({
     try {
       adminSubmissionLoading.onTrue();
       const res = await axiosInstance.post(endpoints.submission.admin.adminPostSubmission, {
-        ...data,
+        postingLinks: [data.postingLink],
         submissionId: submission?.id,
         creatorId: creator?.user?.id,
       });
@@ -696,14 +696,12 @@ const Posting = ({
               <Box
                 sx={{
                   p: 2,
-                  mt: -3.5,
                   borderRadius: 2,
                   border: '1px solid',
                   borderColor: 'divider',
-                  pb: 1,
                 }}
               >
-                <Box display="flex" flexDirection="column" gap={0.5}>
+                <Box display="flex" flexDirection="column">
                   <Stack direction="row" alignItems="center" spacing={2}>
                     <Avatar
                       src={creator?.user?.photoURL}
@@ -716,38 +714,36 @@ const Posting = ({
                     >
                       {creator?.user?.name?.charAt(0).toUpperCase()}
                     </Avatar>
-                        <Typography
-                          variant="subtitle2"
-                          sx={{
-                            fontSize: '1.05rem',
-                            mt: -4,
-                          }}
-                        >
-                      {creator?.user?.name}
-                    </Typography>
-                  </Stack>
-
-                  <Box sx={{ pl: 7 }}>
-                    <Box sx={{ mt: 0 }}>
+                    <Stack>
                       <Typography
-                        variant="body2"
-                        component="a"
-                        href={submission?.content}
-                        target="_blank"
-                        rel="noopener"
+                        variant="subtitle2"
                         sx={{
-                          wordBreak: 'break-word',
-                          color: 'primary.main',
-                          textDecoration: 'none',
-                          '&:hover': {
-                            textDecoration: 'underline',
-                          },
+                          fontSize: '1.05rem',
                         }}
                       >
-                        {submission?.content}
+                        {creator?.user?.name}
                       </Typography>
-                    </Box>
-                  </Box>
+                      <Box sx={{ mt: 0 }}>
+                        <Typography
+                          variant="body2"
+                          component="a"
+                          href={submission?.content}
+                          target="_blank"
+                          rel="noopener"
+                          sx={{
+                            wordBreak: 'break-word',
+                            color: 'primary.main',
+                            textDecoration: 'none',
+                            '&:hover': {
+                              textDecoration: 'underline',
+                            },
+                          }}
+                        >
+                          {submission?.content}
+                        </Typography>
+                      </Box>
+                    </Stack>
+                  </Stack>
                 </Box>
               </Box>
             </Box>

--- a/src/sections/campaign/manage-creator/view/manage-campaign-view.jsx
+++ b/src/sections/campaign/manage-creator/view/manage-campaign-view.jsx
@@ -73,10 +73,6 @@ const ManageCampaignView = () => {
             if (campaign.shortlisted && campaign.status === 'ACTIVE' && !campaign.shortlisted?.isCampaignDone) {
               return true;
             }
-            // Campaigns with approved pitches - these go to active tab
-            if (campaign?.pitch?.status === 'APPROVED' || campaign?.pitch?.status === 'approved') {
-              return true;
-            }
             return false;
           }
         ) || [],


### PR DESCRIPTION
This pull request refactors the admin campaign creator submission posting UI and updates the logic for displaying active campaigns. The main changes include restructuring the data sent in the admin submission API request, improving the layout of the posting component, and refining the filtering logic for active campaigns.

**Admin Submission Data Handling:**
* The API request now sends `postingLinks` as an array containing the single `postingLink` instead of spreading all data fields, ensuring proper backend data structure.

**Campaign Filtering Logic:**
* Removed the condition that included campaigns with approved pitches in the "active" tab, so only campaigns that are truly active and not marked as done are shown.

Fixes following bug issues:
- CCB-536
- CCB-537