### PR TITLE
Fix: Revert confirmed creators filter logic

### DIFF
--- a/src/sections/campaign/discover/admin/campaign-detail-creator/campaign-detail-creator.jsx
+++ b/src/sections/campaign/discover/admin/campaign-detail-creator/campaign-detail-creator.jsx
@@ -187,37 +187,15 @@ const CampaignDetailCreator = ({ campaign, campaignMutate }) => {
     }));
   }, [agreements, campaign]);
 
-  console.log(creatorsWithAgreements);
-
-  const filteredCreators = useMemo(() => {
-    let filtered = creatorsWithAgreements;
-
-    // For v4 campaigns, only show creators with approved pitches
-    if (campaign?.submissionVersion === 'v4') {
-      // Define approved statuses
-      const approvedStatuses = ['approved', 'APPROVED', 'AGREEMENT_PENDING', 'AGREEMENT_SUBMITTED'];
-
-      filtered = creatorsWithAgreements?.filter((elem) => {
-        // Find the pitch for this creator
-        const creatorPitch = campaign?.pitch?.find((p) => p.userId === elem.userId);
-
-        if (!creatorPitch) return false;
-
-        // Check if the pitch has an approved status (check both displayStatus and status)
-        const pitchStatus = creatorPitch.displayStatus || creatorPitch.status;
-        return approvedStatuses.includes(pitchStatus);
-      });
-    }
-
-    // Apply name search filter if query exists
-    if (query) {
-      filtered = filtered?.filter((elem) =>
-        elem?.user?.name?.toLowerCase().includes(query.toLowerCase())
-      );
-    }
-
-    return filtered;
-  }, [creatorsWithAgreements, query, campaign]);
+  const filteredCreators = useMemo(
+    () =>
+      query
+        ? creatorsWithAgreements?.filter((elem) =>
+            elem?.user?.name?.toLowerCase().includes(query.toLowerCase())
+          )
+        : creatorsWithAgreements,
+    [creatorsWithAgreements, query]
+  );
 
   const selectedCreator = watch('creator');
 

--- a/src/sections/campaign/discover/client/v3-pitches/v3-pitch-modal.jsx
+++ b/src/sections/campaign/discover/client/v3-pitches/v3-pitch-modal.jsx
@@ -1927,7 +1927,7 @@ export function ViewGuestCreatorModal({ open, onClose, pitch, isAdmin, campaign,
                       </Typography>
                       {option?.creator?.instagram && (
                         <Typography variant="caption" color="primary.main" sx={{ lineHeight: 1.2 }}>
-                          @{option.creator.instagram}
+                          {option.creator.instagram}
                         </Typography>
                       )}
                     </Stack>


### PR DESCRIPTION
**Campaign creator filtering logic:**

* Simplified the `filteredCreators` logic in `campaign-detail-creator.jsx` to remove pitch approval status filtering for v4 campaigns; now only applies a name search filter if a query is present.

**UI improvements:**

* Updated the Instagram handle display in `v3-pitch-modal.jsx` to remove the '@' prefix, showing only the raw handle.