### PR TITLE
Fix: tab number indicators 

### DIFF
--- a/src/sections/campaign/discover/admin/view/campaign-detail-view.jsx
+++ b/src/sections/campaign/discover/admin/view/campaign-detail-view.jsx
@@ -345,7 +345,7 @@ const CampaignDetailView = ({ id }) => {
                 { label: 'Campaign Details', value: 'campaign-content' },
                 // { label: 'Client Info', value: 'client' },
                 {
-                  label: `Creator Master List (${campaign?.pitch.length})`,
+                  label: `Creator Master List (${campaign?.pitch?.length || 0})`,
                   value: 'pitch',
                 },
                 {
@@ -358,7 +358,7 @@ const CampaignDetailView = ({ id }) => {
                       (sum, a) => sum + (a.isSent === false ? 1 : 0),
                       0
                     );
-                    return `Agreements (${pendingAgreementApproval + pendingSendAgreement})`;
+                    return `Agreements (${(pendingAgreementApproval + pendingSendAgreement) || 0})`;
                   })(),
                   value: 'agreement',
                 },


### PR DESCRIPTION
### UI Fixes on Campaign detail tab views
* Added '0' as default to creator master list and agreements tab number indicators if `undefined` or `NaN` found.