### PR TITLE
fix: disable campaign conversion on campaign edit

### DIFF
--- a/src/sections/campaign/manage/details/UpdateFinaliseCampaign.jsx
+++ b/src/sections/campaign/manage/details/UpdateFinaliseCampaign.jsx
@@ -86,7 +86,7 @@ const UpdateFinaliseCampaign = ({ campaign, campaignMutate }) => {
   const companyId = campaign?.company?.id || campaign?.brand?.company?.id;
 
   // Fetch clients for this company using the new hook
-  const { clients: campaignClients, isLoading: clientsLoading } = useGetClients(companyId);
+  const { clients: campaignClients } = useGetClients(companyId);
 
   // Warning dialog state for v4 submission toggle
   const [v4WarningOpen, setV4WarningOpen] = useState(false);
@@ -108,10 +108,7 @@ const UpdateFinaliseCampaign = ({ campaign, campaignMutate }) => {
         photoURL: ca.admin?.user?.photoURL,
         role: ca.admin?.role?.name || ca.admin?.user.role,
       }));
-  }, [campaign]);
-
-  console.log('existing managers:', existingManagers);
-  console.log('campaign clients:', campaignClients);
+  }, [campaign?.campaignAdmin]);
 
   // UGC_VIDEOS is the default/base deliverable
   const existingDeliverables = useMemo(() => {
@@ -121,7 +118,7 @@ const UpdateFinaliseCampaign = ({ campaign, campaignMutate }) => {
     if (campaign?.ads) delivs.push('ADS');
     if (campaign?.crossPosting) delivs.push('CROSS_POSTING');
     return delivs;
-  }, [campaign]);
+  }, [campaign?.rawFootage, campaign?.photos, campaign?.ads, campaign?.crossPosting]);
 
   const defaultValues = useMemo(
     () => ({
@@ -130,14 +127,7 @@ const UpdateFinaliseCampaign = ({ campaign, campaignMutate }) => {
       deliverables: existingDeliverables,
       isV4Submission: campaign?.submissionVersion === 'v4',
     }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      campaign?.id,
-      campaign?.submissionVersion,
-      campaign?.campaignType,
-      JSON.stringify(existingManagers),
-      JSON.stringify(existingDeliverables),
-    ]
+    [existingManagers, campaign?.submissionVersion, campaign?.campaignType, existingDeliverables]
   );
 
   const methods = useForm({
@@ -247,6 +237,7 @@ const UpdateFinaliseCampaign = ({ campaign, campaignMutate }) => {
               checked={isV4Submission || false}
               onChange={handleV4ToggleChange}
               color="primary"
+              disabled
             />
           </Stack>
           <Typography variant="caption" fontWeight={400} color="text.secondary">

--- a/src/sections/campaign/manage/details/UpdateFinaliseCampaign.jsx
+++ b/src/sections/campaign/manage/details/UpdateFinaliseCampaign.jsx
@@ -249,7 +249,7 @@ const UpdateFinaliseCampaign = ({ campaign, campaignMutate }) => {
           </Typography>
         </Stack>
 
-        <Stack direction="row" spacing={2}>
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
           {/* Left column */}
           <Stack flex={1} spacing={2}>
             <FormField label="Campaign Managers">

--- a/src/sections/campaign/manage/details/UpdateFinaliseCampaign.jsx
+++ b/src/sections/campaign/manage/details/UpdateFinaliseCampaign.jsx
@@ -227,11 +227,13 @@ const UpdateFinaliseCampaign = ({ campaign, campaignMutate }) => {
             <Typography
               sx={{
                 fontWeight: 700,
-                color: (theme) => (theme.palette.mode === 'light' ? 'black' : 'white'),
+                color: '#231F20',
+                opacity: 0.6,
                 fontSize: '0.875rem',
+                mr: -0.5
               }}
             >
-              Enable this as a client campaign?
+              Enable this as a Client Campaign?
             </Typography>
             <Switch
               checked={isV4Submission || false}
@@ -243,7 +245,7 @@ const UpdateFinaliseCampaign = ({ campaign, campaignMutate }) => {
           <Typography variant="caption" fontWeight={400} color="text.secondary">
             {isV4Submission
               ? 'Client users will be added as campaign managers. Disabling will remove them.'
-              : 'Enabling this option will add client users as campaign managers.'}
+              : 'Enabling this option makes it a campaign that the previously selected client will manage.'}
           </Typography>
         </Stack>
 
@@ -290,7 +292,10 @@ const UpdateFinaliseCampaign = ({ campaign, campaignMutate }) => {
                 }
               />
             </FormField>
+          </Stack>
 
+          {/* Right column */}
+          <Stack flex={1} spacing={2}>
             <FormField label="Campaign Type">
               <RHFSelectV2 name="campaignType" placeholder="Select campaign type">
                 {campaignTypeOptions.map((option) => (
@@ -301,19 +306,18 @@ const UpdateFinaliseCampaign = ({ campaign, campaignMutate }) => {
               </RHFSelectV2>
             </FormField>
           </Stack>
+        </Stack>
 
-          {/* Right column */}
-          <Stack flex={1} spacing={2}>
-            <FormField label="Deliverables">
-              <RHFMultiSelect
-                name="deliverables"
-                placeholder="Select deliverable(s)"
-                chip
-                checkbox
-                options={deliverableOptions}
-              />
-            </FormField>
-          </Stack>
+        <Stack>
+          <FormField label="Additional Deliverables">
+            <RHFMultiSelect
+              name="deliverables"
+              placeholder="Select deliverable(s)"
+              chip
+              checkbox
+              options={deliverableOptions}
+            />
+          </FormField>
         </Stack>
 
         {/* Submit Button */}

--- a/src/sections/campaign/manage/details/UpdateGeneralInformation.jsx
+++ b/src/sections/campaign/manage/details/UpdateGeneralInformation.jsx
@@ -165,7 +165,7 @@ const UpdateGeneralInformation = ({ campaign, campaignMutate }) => {
 
   return (
     <FormProvider methods={methods} onSubmit={handleSubmit(onSubmit)}>
-      <Box sx={{ maxWidth: '80%' }}>
+      <Box sx={{ maxWidth: { xs: '100%', sm: '80%' } }}>
         {/* Campaign Title & Industry - Two Columns */}
         <Grid container spacing={2} mb={2}>
           <Grid item xs={12} sm={6}>


### PR DESCRIPTION
**React hook and state management improvements:**

* Refined dependencies for `useMemo` hooks to prevent unnecessary re-renders and ensure correct memoization, particularly for `existingManagers` and `existingDeliverables` (`UpdateFinaliseCampaign.jsx`). [[1]](diffhunk://#diff-e17fb436eb88eef49ba9766c9047e8b3a488293578f5d944e61ac5d5f9eb7f43L111-R111) [[2]](diffhunk://#diff-e17fb436eb88eef49ba9766c9047e8b3a488293578f5d944e61ac5d5f9eb7f43L124-R121) [[3]](diffhunk://#diff-e17fb436eb88eef49ba9766c9047e8b3a488293578f5d944e61ac5d5f9eb7f43L133-R130)
* Removed unused `isLoading` variable from `useGetClients` and cleaned up related console logs for a cleaner codebase (`UpdateFinaliseCampaign.jsx`). [[1]](diffhunk://#diff-e17fb436eb88eef49ba9766c9047e8b3a488293578f5d944e61ac5d5f9eb7f43L89-R89) [[2]](diffhunk://#diff-e17fb436eb88eef49ba9766c9047e8b3a488293578f5d944e61ac5d5f9eb7f43L111-R111)

**UI and styling enhancements:**

* Updated typography and switch styling for the "Enable this as a Client Campaign?" section, including text capitalization, color, opacity, and disabling the switch for clarity (`UpdateFinaliseCampaign.jsx`).
* Improved layout by making the stack direction responsive and reorganizing form fields into clearer left/right columns, enhancing usability on different screen sizes (`UpdateFinaliseCampaign.jsx`). [[1]](diffhunk://#diff-e17fb436eb88eef49ba9766c9047e8b3a488293578f5d944e61ac5d5f9eb7f43L240-R252) [[2]](diffhunk://#diff-e17fb436eb88eef49ba9766c9047e8b3a488293578f5d944e61ac5d5f9eb7f43R295-R298) [[3]](diffhunk://#diff-e17fb436eb88eef49ba9766c9047e8b3a488293578f5d944e61ac5d5f9eb7f43R309-R312) [[4]](diffhunk://#diff-e17fb436eb88eef49ba9766c9047e8b3a488293578f5d944e61ac5d5f9eb7f43L326)

**General layout improvement:**

* Made the `UpdateGeneralInformation` form container responsive by adjusting its `maxWidth` based on screen size (`UpdateGeneralInformation.jsx`).