### PR TITLE
fix: conditional display of campaign objectives

### DIFF
--- a/src/sections/campaign/create/form-v2.jsx
+++ b/src/sections/campaign/create/form-v2.jsx
@@ -435,9 +435,6 @@ function CreateCampaignFormV2({ onClose, mutate: mutateCampaignList }) {
         return [
           'campaignObjectives',
           'secondaryObjectives',
-          'boostContent',
-          'primaryKPI',
-          'performanceBaseline',
         ];
       case 2: // Audience
         return [
@@ -926,10 +923,7 @@ function CreateCampaignFormV2({ onClose, mutate: mutateCampaignList }) {
       case 1: {
         const objectives = formValues.campaignObjectives;
         const secObjectives = formValues.secondaryObjectives;
-        const boost = formValues.boostContent;
-        const kpi = formValues.primaryKPI;
-        const baseline = formValues.performanceBaseline;
-        return objectives && secObjectives && boost && kpi && baseline;
+        return objectives && secObjectives
       }
       case 2: {
         const { country } = formValues;

--- a/src/sections/campaign/manage/details/UpdateObjectives.jsx
+++ b/src/sections/campaign/manage/details/UpdateObjectives.jsx
@@ -103,6 +103,12 @@ const UpdateObjectives = ({ campaign, campaignMutate }) => {
       prevPrimaryObjective.current !== primaryObjective
     ) {
       setValue('secondaryObjectives', [], { shouldDirty: true });
+      // Clear fields if switching to Awareness
+      if (primaryObjective === 'Awareness') {
+        setValue('boostContent', '', { shouldDirty: true });
+        setValue('primaryKPI', '', { shouldDirty: true });
+        setValue('performanceBaseline', '', { shouldDirty: true });
+      }
     }
     prevPrimaryObjective.current = primaryObjective;
   }, [primaryObjective, setValue]);
@@ -166,48 +172,53 @@ const UpdateObjectives = ({ campaign, campaignMutate }) => {
             </FormField>
           </Box>
 
-          {/* Boost/Promote Content */}
-          <Box sx={{ mt: 2 }}>
-            <FormField label="Boost/Promote Content" required={false}>
-              <RHFSelectV2 name="boostContent" placeholder="Select an option" multiple={false}>
-                {boostContentOptions.map((option) => (
-                  <MenuItem key={option.value} value={option.value}>
-                    {option.label}
-                  </MenuItem>
-                ))}
-              </RHFSelectV2>
-            </FormField>
-          </Box>
+          {/* Conditionally render these fields only for Performance */}
+          {primaryObjective === 'Performance' && (
+            <>
+              {/* Boost/Promote Content */}
+              <Box sx={{ mt: 2 }}>
+                <FormField label="Boost/Promote Content" required={false}>
+                  <RHFSelectV2 name="boostContent" placeholder="Select an option" multiple={false}>
+                    {boostContentOptions.map((option) => (
+                      <MenuItem key={option.value} value={option.value}>
+                        {option.label}
+                      </MenuItem>
+                    ))}
+                  </RHFSelectV2>
+                </FormField>
+              </Box>
 
-          {/* Primary KPI */}
-          <Box sx={{ mt: 2 }}>
-            <FormField label="Primary KPI" required={false}>
-              <RHFSelectV2 name="primaryKPI" placeholder="Select an option" multiple={false}>
-                {primaryKPIOptions.map((item) => (
-                  <MenuItem key={item} value={item}>
-                    {item}
-                  </MenuItem>
-                ))}
-              </RHFSelectV2>
-            </FormField>
-          </Box>
+              {/* Primary KPI */}
+              <Box sx={{ mt: 2 }}>
+                <FormField label="Primary KPI" required={false}>
+                  <RHFSelectV2 name="primaryKPI" placeholder="Select an option" multiple={false}>
+                    {primaryKPIOptions.map((item) => (
+                      <MenuItem key={item} value={item}>
+                        {item}
+                      </MenuItem>
+                    ))}
+                  </RHFSelectV2>
+                </FormField>
+              </Box>
 
-          {/* Current Performance Baseline */}
-          <Box sx={{ mt: 2, mb: 4 }}>
-            <FormField label="Current Performance Baseline" required={false}>
-              <Typography mt={-1} mb={0.5} variant="caption" color="#8E8E93">
-                This helps us measure campaign impact and improvement. Enter your current
-                performance baseline (e.g., &quot;2,000 website visits/day&quot; or &quot;500
-                clicks/post&quot; or &quot;200 leads/month&quot; or &quot;150 inquiries/month&quot;)
-              </Typography>
-              <RHFTextField
-                name="performanceBaseline"
-                placeholder="Current Performance Baseline"
-                multiline
-                rows={1}
-              />
-            </FormField>
-          </Box>
+              {/* Current Performance Baseline */}
+              <Box sx={{ mt: 2, mb: 4 }}>
+                <FormField label="Current Performance Baseline" required={false}>
+                  <Typography mt={-1} mb={0.5} variant="caption" color="#8E8E93">
+                    This helps us measure campaign impact and improvement. Enter your current
+                    performance baseline (e.g., &quot;2,000 website visits/day&quot; or &quot;500
+                    clicks/post&quot; or &quot;200 leads/month&quot; or &quot;150 inquiries/month&quot;)
+                  </Typography>
+                  <RHFTextField
+                    name="performanceBaseline"
+                    placeholder="Current Performance Baseline"
+                    multiline
+                    rows={1}
+                  />
+                </FormField>
+              </Box>
+            </>
+          )}
         </Collapse>
 
         {/* Submit Button */}

--- a/src/sections/client/campaign-create/campaign-create-form.jsx
+++ b/src/sections/client/campaign-create/campaign-create-form.jsx
@@ -156,9 +156,9 @@ function ClientCampaignCreateForm({ onClose, mutate }) {
   const objectiveSchema = Yup.object().shape({
     campaignObjectives: Yup.string().required('Campaign objective is required.'),
     secondaryObjectives: Yup.array().max(2, 'You can select up to 2 secondary objectives'),
-    boostContent: Yup.string().required('Boost content is required.'),
-    primaryKPI: Yup.string().required('Primary KPI is required.'),
-    performanceBaseline: Yup.string().required('Performance baseline is required.'),
+    boostContent: Yup.string(),
+    primaryKPI: Yup.string(),
+    performanceBaseline: Yup.string(),
   });
 
   const campaignRequirementSchema = Yup.object().shape({
@@ -374,9 +374,6 @@ function ClientCampaignCreateForm({ onClose, mutate }) {
         return [
           'campaignObjectives',
           'secondaryObjectives',
-          'boostContent',
-          'primaryKPI',
-          'performanceBaseline',
         ];
       case 2: // Audience
         return [
@@ -780,10 +777,7 @@ function ClientCampaignCreateForm({ onClose, mutate }) {
       case 1: // Objective
         return (
           values.campaignObjectives?.length > 0 &&
-          values.secondaryObjectives?.length > 0 &&
-          values.boostContent &&
-          values.primaryKPI &&
-          values.performanceBaseline
+          values.secondaryObjectives?.length > 0
         );
       case 2: // Audience
         return (

--- a/src/sections/client/campaign-create/campaign-objective.jsx
+++ b/src/sections/client/campaign-create/campaign-objective.jsx
@@ -2,14 +2,7 @@ import PropTypes from 'prop-types';
 import { useFormContext } from 'react-hook-form';
 import React, { memo, useRef, useEffect } from 'react';
 
-import {
-  Box,
-  Stack,
-  MenuItem,
-  Collapse,
-  FormLabel,
-  Typography,
-} from '@mui/material';
+import { Box, Stack, MenuItem, Collapse, FormLabel, Typography } from '@mui/material';
 
 import {
   primaryKPIOptions,
@@ -47,16 +40,25 @@ FormField.propTypes = {
   required: PropTypes.bool,
 };
 
-
 const CampaignObjective = () => {
   const { watch, setValue } = useFormContext();
   const primaryObjective = watch('campaignObjectives');
   const secondaryOptions = secondaryObjectivesByPrimary[primaryObjective] || [];
   const prevPrimaryObjective = useRef(primaryObjective);
 
+  // Clear secondary objectives when primary objective changes
   useEffect(() => {
-    if (prevPrimaryObjective.current !== undefined && prevPrimaryObjective.current !== primaryObjective) {
-      setValue('secondaryObjectives', []);
+    if (
+      prevPrimaryObjective.current !== null &&
+      prevPrimaryObjective.current !== primaryObjective
+    ) {
+      setValue('secondaryObjectives', [], { shouldDirty: true });
+      // Clear fields if switching to Awareness
+      if (primaryObjective === 'Awareness') {
+        setValue('boostContent', '', { shouldDirty: true });
+        setValue('primaryKPI', '', { shouldDirty: true });
+        setValue('performanceBaseline', '', { shouldDirty: true });
+      }
     }
     prevPrimaryObjective.current = primaryObjective;
   }, [primaryObjective, setValue]);
@@ -115,52 +117,54 @@ const CampaignObjective = () => {
           </FormField>
         </Box>
 
-        {/* Boost/Promote Content */}
-        <Box sx={{ mt: 2 }}>
-          <FormField label="Boost/Promote Content">
-            <RHFSelectV2
-              name="boostContent"
-              placeholder="Select an option"
-              multiple={false}
-            >
-              {boostContentOptions.map((option) => (
-                <MenuItem key={option.value} value={option.value}>
-                  {option.label}
-                </MenuItem>
-              ))}
-            </RHFSelectV2>
-          </FormField>
-        </Box>
+        {/* Conditionally render these fields only for Performance */}
+        {primaryObjective === 'Performance' && (
+          <>
+            {/* Boost/Promote Content */}
+            <Box sx={{ mt: 2 }}>
+              <FormField label="Boost/Promote Content">
+                <RHFSelectV2 name="boostContent" placeholder="Select an option" multiple={false}>
+                  {boostContentOptions.map((option) => (
+                    <MenuItem key={option.value} value={option.value}>
+                      {option.label}
+                    </MenuItem>
+                  ))}
+                </RHFSelectV2>
+              </FormField>
+            </Box>
 
-        {/* Primary KPI */}
-        <Box sx={{ mt: 2 }}>
-          <FormField label="Primary KPI">
-            <RHFSelectV2
-              name="primaryKPI"
-              placeholder="Select an option"
-              multiple={false}
-            >
-              {primaryKPIOptions.map((item) => (
-                <MenuItem key={item} value={item}>
-                  {item}
-                </MenuItem>
-              ))}
-            </RHFSelectV2>
-          </FormField>
-        </Box>
+            {/* Primary KPI */}
+            <Box sx={{ mt: 2 }}>
+              <FormField label="Primary KPI">
+                <RHFSelectV2 name="primaryKPI" placeholder="Select an option" multiple={false}>
+                  {primaryKPIOptions.map((item) => (
+                    <MenuItem key={item} value={item}>
+                      {item}
+                    </MenuItem>
+                  ))}
+                </RHFSelectV2>
+              </FormField>
+            </Box>
 
-        {/* Current Performance Baseline */}
-        <Box sx={{ mt: 2, mb: 4 }}>
-          <FormField label="Current Performance Baseline">
-            <Typography mt={-1} mb={0.5} variant='caption' color="#8E8E93">This helps us measure campaign impact and improvement. Enter your current performance baseline (e.g., &quot;2,000 website visits/day&quot; or &quot;500 clicks/post&quot; or &quot;200 leads/month&quot; or &quot;150 inquiries/month&quot;)</Typography>
-            <RHFTextField
-              name="performanceBaseline"
-              placeholder="Current Performance Baseline"
-              multiline
-              rows={1}
-            />
-          </FormField>
-        </Box>
+            {/* Current Performance Baseline */}
+            <Box sx={{ mt: 2, mb: 4 }}>
+              <FormField label="Current Performance Baseline">
+                <Typography mt={-1} mb={0.5} variant="caption" color="#8E8E93">
+                  This helps us measure campaign impact and improvement. Enter your current
+                  performance baseline (e.g., &quot;2,000 website visits/day&quot; or &quot;500
+                  clicks/post&quot; or &quot;200 leads/month&quot; or &quot;150
+                  inquiries/month&quot;)
+                </Typography>
+                <RHFTextField
+                  name="performanceBaseline"
+                  placeholder="Current Performance Baseline"
+                  multiline
+                  rows={1}
+                />
+              </FormField>
+            </Box>
+          </>
+        )}
       </Collapse>
     </Box>
   );


### PR DESCRIPTION
This pull request updates the campaign creation and management forms to ensure that the "Boost Content", "Primary KPI", and "Performance Baseline" fields are only required and visible when the primary campaign objective is set to "Performance". It also improves form validation and field clearing logic when switching objectives.

**Conditional field rendering and validation:**

* The "Boost Content", "Primary KPI", and "Performance Baseline" fields are now only displayed and required when the primary objective is "Performance" in both the client and admin campaign forms. [[1]](diffhunk://#diff-468c9acc5549935bdb1b411679d092fbe8e1abb643f8720a16d314082c86a1c9R120-R126) [[2]](diffhunk://#diff-80ddc714e14fcbdd427831e170fd6f5b6f81e3d65e283ed32e828b1b67f8ba52R175-R177) [[3]](diffhunk://#diff-468c9acc5549935bdb1b411679d092fbe8e1abb643f8720a16d314082c86a1c9R166-R167) [[4]](diffhunk://#diff-80ddc714e14fcbdd427831e170fd6f5b6f81e3d65e283ed32e828b1b67f8ba52R220-R221)
* Validation schemas have been updated so these fields are only required for "Performance" objectives, not for others.

**Form logic improvements:**

* When switching the primary objective to "Awareness", the related fields ("Boost Content", "Primary KPI", and "Performance Baseline") are cleared to avoid carrying over irrelevant data. [[1]](diffhunk://#diff-468c9acc5549935bdb1b411679d092fbe8e1abb643f8720a16d314082c86a1c9L50-R61) [[2]](diffhunk://#diff-80ddc714e14fcbdd427831e170fd6f5b6f81e3d65e283ed32e828b1b67f8ba52R106-R111)

**Step completion logic updates:**

* The logic for progressing through the form steps has been updated to only require "Boost Content", "Primary KPI", and "Performance Baseline" when the objective is "Performance". [[1]](diffhunk://#diff-1d15a9702463dcb395eba67b6a4578263acb3e367db561ce8bc4b032a02257c5L438-L440) [[2]](diffhunk://#diff-d344bae0d7324faf69965b2b103c1fd0f902a37206bfdaf59ad80a167739cd57L377-L379) [[3]](diffhunk://#diff-1d15a9702463dcb395eba67b6a4578263acb3e367db561ce8bc4b032a02257c5L929-R926) [[4]](diffhunk://#diff-d344bae0d7324faf69965b2b103c1fd0f902a37206bfdaf59ad80a167739cd57L783-R780)

**Code cleanup:**

* Minor code style and import formatting improvements in `campaign-objective.jsx`.

These changes collectively make the campaign creation and management process more intuitive and ensure that users only see and are required to fill out relevant fields based on their selected objectives.