### PR TITLE
CCD-581: Creator Discovery Tool - Phase 1

### DIFF
--- a/src/hooks/use-get-discovery-creators.js
+++ b/src/hooks/use-get-discovery-creators.js
@@ -16,11 +16,14 @@ import { fetcher, endpoints } from 'src/utils/axios';
  * @param {string} [filters.hashtag]
  */
 const useGetDiscoveryCreators = (filters = {}) => {
+  const page = filters.page || 1;
+  const limit = filters.limit || 20;
+
   const url = useMemo(() => {
     const params = new URLSearchParams();
     params.set('platform', filters.platform || 'all');
-    params.set('page', '1');
-    params.set('limit', '50');
+    params.set('page', String(page));
+    params.set('limit', String(limit));
     params.set('hydrateMissing', 'true');
 
     if (filters.gender) params.set('gender', filters.gender);
@@ -33,12 +36,12 @@ const useGetDiscoveryCreators = (filters = {}) => {
     if (filters.interests?.length) params.set('interests', JSON.stringify(filters.interests));
 
     return `${endpoints.discovery.creators}?${params.toString()}`;
-  }, [filters]);
+  }, [filters, page, limit]);
 
   const { data, isLoading, mutate, error } = useSWR(url, fetcher, {
     revalidateOnFocus: false,
     revalidateOnMount: true,
-    keepPreviousData: false,
+    keepPreviousData: true,
   });
 
   const memoizedValue = useMemo(
@@ -47,10 +50,11 @@ const useGetDiscoveryCreators = (filters = {}) => {
       pagination: data?.pagination || null,
       availableLocations: data?.availableLocations || {},
       isLoading,
+      pageSize: limit,
       mutate,
       isError: error,
     }),
-    [data, isLoading, mutate, error]
+    [data, isLoading, limit, mutate, error]
   );
 
   return memoizedValue;

--- a/src/hooks/use-get-discovery-creators.js
+++ b/src/hooks/use-get-discovery-creators.js
@@ -1,0 +1,57 @@
+import useSWR from 'swr';
+import { useMemo } from 'react';
+
+import { fetcher, endpoints } from 'src/utils/axios';
+
+/**
+ * @param {Object} filters
+ * @param {string} [filters.platform='all']
+ * @param {string} [filters.gender]
+ * @param {string} [filters.ageRange]
+ * @param {string} [filters.country]
+ * @param {string} [filters.city]
+ * @param {string} [filters.creditTier]
+ * @param {string[]} [filters.interests]
+ * @param {string} [filters.keyword]
+ */
+const useGetDiscoveryCreators = (filters = {}) => {
+  const url = useMemo(() => {
+    const params = new URLSearchParams();
+    params.set('platform', filters.platform || 'all');
+    params.set('page', '1');
+    params.set('limit', '50');
+    params.set('hydrateMissing', 'true');
+
+    if (filters.gender) params.set('gender', filters.gender);
+    if (filters.ageRange) params.set('ageRange', filters.ageRange);
+    if (filters.country) params.set('country', filters.country);
+    if (filters.city) params.set('city', filters.city);
+    if (filters.creditTier) params.set('creditTier', filters.creditTier);
+    if (filters.keyword) params.set('keyword', filters.keyword);
+    if (filters.interests?.length) params.set('interests', JSON.stringify(filters.interests));
+
+    return `${endpoints.discovery.creators}?${params.toString()}`;
+  }, [filters]);
+
+  const { data, isLoading, mutate, error } = useSWR(url, fetcher, {
+    revalidateOnFocus: false,
+    revalidateOnMount: true,
+    keepPreviousData: true,
+  });
+
+  const memoizedValue = useMemo(
+    () => ({
+      creators: data?.data || [],
+      pagination: data?.pagination || null,
+      availableLocations: data?.availableLocations || {},
+      isLoading,
+      mutate,
+      isError: error,
+    }),
+    [data, isLoading, mutate, error]
+  );
+
+  return memoizedValue;
+};
+
+export default useGetDiscoveryCreators;

--- a/src/hooks/use-get-discovery-creators.js
+++ b/src/hooks/use-get-discovery-creators.js
@@ -13,6 +13,7 @@ import { fetcher, endpoints } from 'src/utils/axios';
  * @param {string} [filters.creditTier]
  * @param {string[]} [filters.interests]
  * @param {string} [filters.keyword]
+ * @param {string} [filters.hashtag]
  */
 const useGetDiscoveryCreators = (filters = {}) => {
   const url = useMemo(() => {
@@ -28,6 +29,7 @@ const useGetDiscoveryCreators = (filters = {}) => {
     if (filters.city) params.set('city', filters.city);
     if (filters.creditTier) params.set('creditTier', filters.creditTier);
     if (filters.keyword) params.set('keyword', filters.keyword);
+    if (filters.hashtag) params.set('hashtag', filters.hashtag);
     if (filters.interests?.length) params.set('interests', JSON.stringify(filters.interests));
 
     return `${endpoints.discovery.creators}?${params.toString()}`;

--- a/src/hooks/use-get-discovery-creators.js
+++ b/src/hooks/use-get-discovery-creators.js
@@ -38,7 +38,7 @@ const useGetDiscoveryCreators = (filters = {}) => {
   const { data, isLoading, mutate, error } = useSWR(url, fetcher, {
     revalidateOnFocus: false,
     revalidateOnMount: true,
-    keepPreviousData: true,
+    keepPreviousData: false,
   });
 
   const memoizedValue = useMemo(

--- a/src/layouts/dashboard/config-navigation.jsx
+++ b/src/layouts/dashboard/config-navigation.jsx
@@ -166,6 +166,12 @@ export function useNavData() {
             path: paths.dashboard.company.discover,
             icon: ICONS.clients,
           },
+          {
+            roles: ['superadmin', 'CSM', 'CSL', 'client', 'god'],
+            title: 'Creator Discovery Tool',
+            path: paths.dashboard.discoveryTool,
+            icon: <Iconify icon="material-symbols:feature-search-outline" width={25} />,
+          },
           // {
           //   title: 'My Tasks',
           //   path: paths.dashboard.kanban,

--- a/src/layouts/dashboard/main.jsx
+++ b/src/layouts/dashboard/main.jsx
@@ -83,8 +83,9 @@ export default function Main({ children, sx, ...other }) {
           <Box
             sx={{
               position: 'absolute',
-              bottom: 15,
-              right: 45,
+              zIndex: 100,
+              bottom: 10,
+              right: 25,
               textAlign: 'right',
             }}
           >

--- a/src/pages/dashboard/discovery-tool/discovery-tool.jsx
+++ b/src/pages/dashboard/discovery-tool/discovery-tool.jsx
@@ -1,0 +1,14 @@
+import { Helmet } from 'react-helmet-async';
+import DiscoveryToolView from 'src/sections/discovery-tool/view/discovery-tool-view'
+
+export default function Page() {
+  return (
+    <>
+      <Helmet>
+        <title>Creator Discovery Tool</title>
+      </Helmet>
+
+      <DiscoveryToolView />
+    </>
+  );
+}

--- a/src/routes/paths.js
+++ b/src/routes/paths.js
@@ -30,6 +30,7 @@ export const paths = {
     kanban: `${ROOTS.DASHBOARD}/kanban`,
     analytics: `${ROOTS.DASHBOARD}/analytics`,
     client: `${ROOTS.DASHBOARD}/client`,
+    discoveryTool: `${ROOTS.DASHBOARD}/discovery-tool`,
     faq: `${ROOTS.DASHBOARD}/faq`,
     company: {
       root: `${ROOTS.DASHBOARD}/company`,

--- a/src/routes/sections/dashboard.jsx
+++ b/src/routes/sections/dashboard.jsx
@@ -88,7 +88,9 @@ const AdminTaskPage = lazy(() => import('src/pages/dashboard/admin/tasks'));
 
 // Performance report
 const Report = lazy(() => import('src/pages/dashboard/report/report'));
-const ReportView = lazy(() => import('src/sections/report/view/reporting-view'));
+
+// Creator Discovery Tool
+const DiscoveryTool = lazy(() => import('src/pages/dashboard/discovery-tool/discovery-tool'));
 
 // Roles
 const Roles = lazy(() => import('src/pages/dashboard/roles/roles'));
@@ -233,6 +235,14 @@ export const dashboardRoutes = [
             element: <ReportingView />,
           },
         ],
+      },
+      {
+        path: 'discovery-tool',
+        element: (
+          <RoleBasedGuard roles={['superadmin', 'god']} hasContent>
+            <DiscoveryTool />
+          </RoleBasedGuard>
+        ),
       },
       // For Finance
       {

--- a/src/sections/creator/media-kit/view-instagram.jsx
+++ b/src/sections/creator/media-kit/view-instagram.jsx
@@ -41,8 +41,10 @@ export const formatNumber = (num) => {
 const TopContentGrid = ({ topContents, mobileCarousel }) => {
   const { isMobile, theme } = useMediaKitResponsive();
 
+  console.log(topContents)
+
   const displayContent = (topContents || [])
-    .sort((a, b) => a?.like_count > b?.like_count)
+    .sort((a, b) => b?.like_count > a?.like_count)
     .slice(0, 3);
 
   if (isMobile) {

--- a/src/sections/discovery-tool/components/CreatorCard.jsx
+++ b/src/sections/discovery-tool/components/CreatorCard.jsx
@@ -104,10 +104,9 @@ const VideoThumbnail = ({ video, platform, tiktokHandle }) => {
       rel={permalink ? 'noopener noreferrer' : undefined}
       sx={{
         position: 'relative',
-        width: 120,
+        width: '100%',
         height: 200,
         overflow: 'hidden',
-        flexShrink: 0,
         cursor: permalink ? 'pointer' : 'default',
         textDecoration: 'none',
         '&:hover .thumbnail-overlay': {
@@ -164,13 +163,13 @@ const VideoThumbnail = ({ video, platform, tiktokHandle }) => {
         }}
       >
         <Stack direction="row" alignItems="center" spacing={0.5}>
-          <Iconify icon="mdi:heart-outline" width={14} color="#fff" />
+          <Iconify icon="mdi:heart-outline" width={20} color="#fff" />
           <Typography sx={{ color: '#fff', fontSize: 11, fontWeight: 600 }}>
             {formatNumber(likes || 0)}
           </Typography>
         </Stack>
         <Stack direction="row" alignItems="center" spacing={0.5}>
-          <Iconify icon="mdi:comment-outline" width={14} color="#fff" />
+          <Iconify icon="tabler:message-circle" width={20} color="#fff" />
           <Typography sx={{ color: '#fff', fontSize: 11, fontWeight: 600 }}>
             {formatNumber(comments || 0)}
           </Typography>
@@ -194,11 +193,14 @@ const CreatorCard = ({ creator, selected, onSelect }) => {
   const handle = getPlatformHandle(creator, platform);
   const platformIcon = getPlatformIcon(platform);
 
-  const profilePicture = creator.instagram?.profilePictureUrl || null;
+  const profilePicture = 
+    platform === 'instagram' 
+    ? creator.instagram?.profilePictureUrl || null
+    : creator.tiktok?.profilePictureUrl || null;
   const bio =
     platform === 'tiktok'
-      ? creator.tiktok?.biography || creator.instagram?.biography || creator.about || null
-      : creator.instagram?.biography || creator.tiktok?.biography || creator.about || null;
+      ? creator.tiktok?.biography || creator.about || null
+      : creator.instagram?.biography || creator.about || null;
 
   const followers = platformData.followers || 0;
   const engagementRate = platformData.engagementRate || 0;
@@ -243,6 +245,7 @@ const CreatorCard = ({ creator, selected, onSelect }) => {
           minWidth: 200,
           p: 2,
           display: 'flex',
+          flex: 0.5,
           flexDirection: 'column',
           alignItems: 'center',
           justifyContent: 'center',
@@ -358,7 +361,7 @@ const CreatorCard = ({ creator, selected, onSelect }) => {
       </Box>
 
       {/* ─── Right: Top Videos ────────────────────────────────────────────────── */}
-      <Stack direction="row" spacing={1}>
+      <Stack direction="row" spacing={1} flex={1}>
         {topVideos.length > 0 ? (
           topVideos.map((video, idx) => (
             <VideoThumbnail

--- a/src/sections/discovery-tool/components/CreatorCard.jsx
+++ b/src/sections/discovery-tool/components/CreatorCard.jsx
@@ -223,7 +223,7 @@ const CreatorCard = ({ creator, selected, onSelect }) => {
           inset: 0,
           background: 'linear-gradient(90deg, #1340FF 0%, #FFFFFF 22%)',
           opacity: selected ? 1 : 0,
-          transition: 'opacity 240ms ease',
+          transition: 'opacity 150ms ease',
           pointerEvents: 'none',
           zIndex: 0,
         },

--- a/src/sections/discovery-tool/components/CreatorCard.jsx
+++ b/src/sections/discovery-tool/components/CreatorCard.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { Box, Chip, Stack, Avatar, Checkbox, Typography } from '@mui/material';
 
 import { formatNumber } from 'src/utils/socialMetricsCalculator';
+import { createSocialProfileUrl } from 'src/utils/media-kit-utils';
 
 import Iconify from 'src/components/iconify';
 
@@ -306,7 +307,27 @@ const CreatorCard = ({ creator, selected, onSelect }) => {
         {handle && (
           <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mt: 0.25 }}>
             {platformIcon && <Iconify icon={platformIcon} width={14} color="text.secondary" />}
-            <Typography sx={{ fontSize: 12, color: 'text.secondary' }}>{handle}</Typography>
+            <a
+              href={createSocialProfileUrl(handle, platform)}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ textDecoration: 'none', color: 'inherit' }}
+            >
+              <Typography
+                sx={{
+                  fontSize: 12,
+                  color: 'text.secondary',
+                  textDecoration: 'none',
+                  cursor: 'pointer',
+                  transition: 'text-decoration 0.15s',
+                  '&:hover': {
+                    textDecoration: 'underline',
+                  },
+                }}
+              >
+                {handle}
+              </Typography>
+            </a>
           </Stack>
         )}
 

--- a/src/sections/discovery-tool/components/CreatorCard.jsx
+++ b/src/sections/discovery-tool/components/CreatorCard.jsx
@@ -255,25 +255,28 @@ const CreatorCard = ({ creator, selected, onSelect }) => {
           borderRadius: 2,
           boxShadow: '2px 2px 2px 1px rgba(0,0,0,0.08)',
           transition: 'box-shadow 0.2s, transform 0.3s',
+          cursor: 'pointer',
           '&:hover': {
             boxShadow: '3px 3px 5px 2px rgba(0,0,0,0.5)',
             transform: 'translateY(-1px)',
           },
         }}
+        onClick={() => onSelect?.(creator.rowId || creator.userId)}
       >
         {/* Selection checkbox */}
         <Checkbox
           checked={selected}
-          onChange={() => onSelect?.(creator.rowId || creator.userId)}
+          readOnly
           size="medium"
-					checkedIcon={<Iconify icon='fluent-mdl2:checkbox-composite' width={14} />}
-					icon={<Iconify icon='fluent-mdl2:checkbox' width={14} />}
+          checkedIcon={<Iconify icon='fluent-mdl2:checkbox-composite' width={14} />}
+          icon={<Iconify icon='fluent-mdl2:checkbox' width={14} />}
           sx={{
             position: 'absolute',
             top: 14,
             left: 14,
             p: 0,
             color: '#7B7B7B',
+            pointerEvents: 'none',
             '&.Mui-checked': {
               color: '#1340FF',
             },

--- a/src/sections/discovery-tool/components/CreatorCard.jsx
+++ b/src/sections/discovery-tool/components/CreatorCard.jsx
@@ -1,10 +1,11 @@
-import PropTypes from 'prop-types';
 import { useState } from 'react';
+import PropTypes from 'prop-types';
 
-import { Box, Chip, Stack, Avatar, Checkbox, Typography, Icon } from '@mui/material';
+import { Box, Chip, Stack, Avatar, Checkbox, Typography } from '@mui/material';
+
+import { formatNumber } from 'src/utils/socialMetricsCalculator';
 
 import Iconify from 'src/components/iconify';
-import { formatNumber } from 'src/utils/socialMetricsCalculator';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -340,7 +341,7 @@ const CreatorCard = ({ creator, selected, onSelect }) => {
         }}
       >
         {/* Stats row */}
-        <Stack direction="row" justifyContent={'space-between'} sx={{ mb: 2 }}>
+        <Stack direction="row" justifyContent="space-between" sx={{ mb: 2 }}>
           <StatItem label="Followers" value={formatNumber(followers)} />
           <StatItem label="Engagement Rate" value={formatEngagementRate(engagementRate)} />
           <StatItem label="Avg Likes" value={formatNumber(avgLikes)} />

--- a/src/sections/discovery-tool/components/CreatorCard.jsx
+++ b/src/sections/discovery-tool/components/CreatorCard.jsx
@@ -1,0 +1,420 @@
+import PropTypes from 'prop-types';
+import { useState } from 'react';
+
+import { Box, Chip, Stack, Avatar, Checkbox, Typography, Icon } from '@mui/material';
+
+import Iconify from 'src/components/iconify';
+import { formatNumber } from 'src/utils/socialMetricsCalculator';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const formatEngagementRate = (rate) => {
+  if (!rate && rate !== 0) return '0%';
+  return `${Number(rate).toFixed(2)}%`;
+};
+
+/** Pick the primary platform stats for the card */
+const resolvePlatformData = (creator) => {
+  if (creator.platform === 'instagram' && creator.instagram?.connected) {
+    return { platform: 'instagram', ...creator.instagram };
+  }
+
+  if (creator.platform === 'tiktok' && creator.tiktok?.connected) {
+    return { platform: 'tiktok', ...creator.tiktok };
+  }
+
+  const ig = creator.instagram;
+  const tt = creator.tiktok;
+
+  // Prefer the platform with a connection; if both, pick the one with more followers
+  if (ig?.connected && tt?.connected) {
+    return ig.followers >= tt.followers
+      ? { platform: 'instagram', ...ig }
+      : { platform: 'tiktok', ...tt };
+  }
+  if (ig?.connected) return { platform: 'instagram', ...ig };
+  if (tt?.connected) return { platform: 'tiktok', ...tt };
+  return { platform: null };
+};
+
+const getPlatformHandle = (creator, platform) => {
+  if (platform === 'instagram')
+    return creator.handles?.instagram ? `${creator.handles.instagram}` : null;
+  if (platform === 'tiktok') return creator.handles?.tiktok ? `${creator.handles.tiktok}` : null;
+  return null;
+};
+
+const getPlatformIcon = (platform) => {
+  if (platform === 'instagram') return 'mdi:instagram';
+  if (platform === 'tiktok') return 'ic:baseline-tiktok';
+  return null;
+};
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+const StatItem = ({ label, value }) => (
+  <Box>
+    <Typography
+      variant="caption"
+      sx={{
+        color: '#1340FF',
+        fontWeight: 700,
+      }}
+    >
+      {label}
+    </Typography>
+    <Typography
+      variant="h3"
+      sx={{ fontWeight: 400, fontFamily: 'Instrument Serif', color: '#1340FF' }}
+    >
+      {value}
+    </Typography>
+  </Box>
+);
+
+StatItem.propTypes = {
+  label: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+};
+
+const VideoThumbnail = ({ video, platform, tiktokHandle }) => {
+  const [hasImageError, setHasImageError] = useState(false);
+
+  const thumbnailUrl =
+    platform === 'instagram' ? video.thumbnail_url || video.media_url : video.cover_image_url;
+
+  const likes = platform === 'instagram' ? video.like_count : video.like_count;
+  const comments = platform === 'instagram' ? video.comments_count : video.comment_count;
+
+  const normalizedTiktokHandle = tiktokHandle ? String(tiktokHandle).replace(/^@/, '') : null;
+  const tiktokCanonicalUrl =
+    video.video_url ||
+    (normalizedTiktokHandle && video.video_id
+      ? `https://www.tiktok.com/@${normalizedTiktokHandle}/video/${video.video_id}`
+      : null);
+
+  const permalink =
+    platform === 'instagram' ? video.permalink : tiktokCanonicalUrl || video.embed_link;
+
+  return (
+    <Box
+      component={permalink ? 'a' : 'div'}
+      href={permalink || undefined}
+      target={permalink ? '_blank' : undefined}
+      rel={permalink ? 'noopener noreferrer' : undefined}
+      sx={{
+        position: 'relative',
+        width: 120,
+        height: 200,
+        overflow: 'hidden',
+        flexShrink: 0,
+        cursor: permalink ? 'pointer' : 'default',
+        textDecoration: 'none',
+        '&:hover .thumbnail-overlay': {
+          opacity: 1,
+        },
+      }}
+    >
+      {/* Thumbnail image */}
+      {thumbnailUrl && !hasImageError && (
+        <Box
+          component="img"
+          src={thumbnailUrl}
+          alt="Video thumbnail"
+          sx={{
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+          }}
+          onError={() => {
+            setHasImageError(true);
+          }}
+        />
+      )}
+
+      {/* Fallback when no thumbnail */}
+      {(!thumbnailUrl || hasImageError) && (
+        <Box
+          sx={{
+            width: '100%',
+            height: '100%',
+            bgcolor: 'grey.200',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <Iconify icon="mdi:video-outline" width={32} color="grey.500" />
+        </Box>
+      )}
+
+      {/* Stats overlay at bottom */}
+      <Box
+        sx={{
+          position: 'absolute',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          background: 'linear-gradient(transparent, rgba(0,0,0,0.6))',
+          px: 1,
+          py: 0.75,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1.5,
+        }}
+      >
+        <Stack direction="row" alignItems="center" spacing={0.5}>
+          <Iconify icon="mdi:heart-outline" width={14} color="#fff" />
+          <Typography sx={{ color: '#fff', fontSize: 11, fontWeight: 600 }}>
+            {formatNumber(likes || 0)}
+          </Typography>
+        </Stack>
+        <Stack direction="row" alignItems="center" spacing={0.5}>
+          <Iconify icon="mdi:comment-outline" width={14} color="#fff" />
+          <Typography sx={{ color: '#fff', fontSize: 11, fontWeight: 600 }}>
+            {formatNumber(comments || 0)}
+          </Typography>
+        </Stack>
+      </Box>
+    </Box>
+  );
+};
+
+VideoThumbnail.propTypes = {
+  video: PropTypes.object.isRequired,
+  platform: PropTypes.oneOf(['instagram', 'tiktok']).isRequired,
+  tiktokHandle: PropTypes.string,
+};
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
+const CreatorCard = ({ creator, selected, onSelect }) => {
+  const platformData = resolvePlatformData(creator);
+  const { platform } = platformData;
+  const handle = getPlatformHandle(creator, platform);
+  const platformIcon = getPlatformIcon(platform);
+
+  const profilePicture = creator.instagram?.profilePictureUrl || null;
+  const bio =
+    platform === 'tiktok'
+      ? creator.tiktok?.biography || creator.instagram?.biography || creator.about || null
+      : creator.instagram?.biography || creator.tiktok?.biography || creator.about || null;
+
+  const followers = platformData.followers || 0;
+  const engagementRate = platformData.engagementRate || 0;
+  const avgLikes = platformData.averageLikes || 0;
+  const avgSaves = platformData.averageSaves || 0;
+  const avgShares = platformData.averageShares || 0;
+
+  const topVideos = (platformData.topVideos || []).slice(0, 3);
+
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        overflow: 'hidden',
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        bgcolor: 'background.paper',
+        '&::before': {
+          content: '""',
+          position: 'absolute',
+          inset: 0,
+          background: 'linear-gradient(90deg, #1340FF 0%, #FFFFFF 22%)',
+          opacity: selected ? 1 : 0,
+          transition: 'opacity 240ms ease',
+          pointerEvents: 'none',
+          zIndex: 0,
+        },
+        '& > *': {
+          position: 'relative',
+          zIndex: 1,
+        },
+        p: 1,
+        gap: 2,
+      }}
+    >
+      {/* ─── Left: User Card ─────────────────────────────────────────────────── */}
+      <Box
+        sx={{
+          width: 200,
+          height: 200,
+          minWidth: 200,
+          p: 2,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          position: 'relative',
+          bgcolor: '#F5F5F5',
+          borderRadius: 2,
+          boxShadow: '2px 2px 2px 1px rgba(0,0,0,0.08)',
+          transition: 'box-shadow 0.2s, transform 0.3s',
+          '&:hover': {
+            boxShadow: '3px 3px 5px 2px rgba(0,0,0,0.5)',
+            transform: 'translateY(-1px)',
+          },
+        }}
+      >
+        {/* Selection checkbox */}
+        <Checkbox
+          checked={selected}
+          onChange={() => onSelect?.(creator.rowId || creator.userId)}
+          size="medium"
+					checkedIcon={<Iconify icon='fluent-mdl2:checkbox-composite' width={14} />}
+					icon={<Iconify icon='fluent-mdl2:checkbox' width={14} />}
+          sx={{
+            position: 'absolute',
+            top: 14,
+            left: 14,
+            p: 0,
+            color: '#7B7B7B',
+            '&.Mui-checked': {
+              color: '#1340FF',
+            },
+          }}
+        />
+
+        {/* Profile picture */}
+        <Avatar src={profilePicture} alt={creator.name} sx={{ width: 61, height: 61, mb: 1 }} />
+
+        {/* Name */}
+        <Typography
+          sx={{
+            fontWeight: 600,
+            fontSize: 12,
+            textAlign: 'center',
+            lineHeight: 1.3,
+            maxWidth: '100%',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {creator.name}
+        </Typography>
+
+        {/* Social handle */}
+        {handle && (
+          <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mt: 0.25 }}>
+            {platformIcon && <Iconify icon={platformIcon} width={14} color="text.secondary" />}
+            <Typography sx={{ fontSize: 12, color: 'text.secondary' }}>{handle}</Typography>
+          </Stack>
+        )}
+
+        {/* Interests */}
+        {creator.interests?.length > 0 && (
+          <Stack direction="row" flexWrap="wrap" justifyContent="center" gap={0.5} sx={{ mt: 1.5 }}>
+            {creator.interests.slice(0, 3).map((interest) => (
+              <Chip
+                key={interest}
+                label={interest}
+                size="small"
+                variant="outlined"
+                sx={{
+                  fontSize: 7,
+                  fontWeight: 600,
+                  textTransform: 'uppercase',
+                  bgcolor: '#fff',
+                  borderColor: '#EBEBEB',
+                  color: '#8E8E93',
+                  boxShadow: '0px -2px 0px 0px #EBEBEB inset',
+                  borderRadius: '4px',
+                }}
+              />
+            ))}
+          </Stack>
+        )}
+      </Box>
+
+      {/* ─── Middle: Stats + Bio ──────────────────────────────────────────────── */}
+      <Box
+        sx={{
+          flex: 1,
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        {/* Stats row */}
+        <Stack direction="row" justifyContent={'space-between'} sx={{ mb: 2 }}>
+          <StatItem label="Followers" value={formatNumber(followers)} />
+          <StatItem label="Engagement Rate" value={formatEngagementRate(engagementRate)} />
+          <StatItem label="Avg Likes" value={formatNumber(avgLikes)} />
+          {platform !== 'tiktok' && <StatItem label="Avg Saves" value={formatNumber(avgSaves)} />}
+          <StatItem label="Avg Shares" value={formatNumber(avgShares)} />
+        </Stack>
+
+        {/* Bio / About */}
+        <Typography
+          sx={{
+            fontSize: 13,
+            color: 'text.primary',
+            lineHeight: 1.6,
+          }}
+        >
+          {bio || 'No bio available.'}
+        </Typography>
+      </Box>
+
+      {/* ─── Right: Top Videos ────────────────────────────────────────────────── */}
+      <Stack direction="row" spacing={1}>
+        {topVideos.length > 0 ? (
+          topVideos.map((video, idx) => (
+            <VideoThumbnail
+              key={video.id || video.video_id || idx}
+              video={video}
+              platform={platform}
+              tiktokHandle={creator.handles?.tiktok}
+            />
+          ))
+        ) : (
+          <Box
+            sx={{
+              width: 150,
+              height: 200,
+              borderRadius: 1.5,
+              bgcolor: 'grey.100',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Typography sx={{ fontSize: 12, color: 'text.disabled' }}>No videos</Typography>
+          </Box>
+        )}
+      </Stack>
+    </Box>
+  );
+};
+
+CreatorCard.propTypes = {
+  creator: PropTypes.shape({
+    rowId: PropTypes.string,
+    platform: PropTypes.oneOf(['instagram', 'tiktok']),
+    userId: PropTypes.string,
+    creatorId: PropTypes.string,
+    name: PropTypes.string,
+    gender: PropTypes.string,
+    age: PropTypes.number,
+    location: PropTypes.string,
+    creditTier: PropTypes.string,
+    handles: PropTypes.shape({
+      instagram: PropTypes.string,
+      tiktok: PropTypes.string,
+    }),
+    interests: PropTypes.arrayOf(PropTypes.string),
+    about: PropTypes.string,
+    instagram: PropTypes.object,
+    tiktok: PropTypes.object,
+  }).isRequired,
+  selected: PropTypes.bool,
+  onSelect: PropTypes.func,
+};
+
+CreatorCard.defaultProps = {
+  selected: false,
+  onSelect: undefined,
+};
+
+export default CreatorCard;

--- a/src/sections/discovery-tool/components/CreatorList.jsx
+++ b/src/sections/discovery-tool/components/CreatorList.jsx
@@ -2,8 +2,6 @@ import PropTypes from 'prop-types';
 
 import { Box, Stack, Button, Divider, Skeleton, Typography } from '@mui/material';
 
-import Iconify from 'src/components/iconify';
-
 import CreatorCard from './CreatorCard';
 
 // ─── Loading Skeleton ─────────────────────────────────────────────────────────

--- a/src/sections/discovery-tool/components/CreatorList.jsx
+++ b/src/sections/discovery-tool/components/CreatorList.jsx
@@ -1,0 +1,160 @@
+import PropTypes from 'prop-types';
+
+import { Box, Stack, Divider, Skeleton, Typography } from '@mui/material';
+
+import CreatorCard from './CreatorCard';
+
+// ─── Loading Skeleton ─────────────────────────────────────────────────────────
+
+const CreatorCardSkeleton = () => (
+  <Box
+    sx={{
+      display: 'flex',
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 2,
+      p: 1
+    }}
+  >
+    {/* Left */}
+    <Box sx={{ width: 188, display: 'flex', flexDirection: 'column', alignItems: 'center', borderColor: 'divider' }}>
+      <Skeleton variant="circular" width={72} height={72} />
+      <Skeleton width={100} height={18} sx={{ mt: 1 }} />
+      <Skeleton width={80} height={14} sx={{ mt: 0.5 }} />
+      <Stack direction="row" spacing={0.5} sx={{ mt: 1.5 }}>
+        <Skeleton width={50} height={22} variant="rounded" />
+        <Skeleton width={50} height={22} variant="rounded" />
+        <Skeleton width={50} height={22} variant="rounded" />
+      </Stack>
+    </Box>
+
+    {/* Middle */}
+    <Box sx={{ flex: 1 }}>
+      <Stack direction="row" justifyContent={'space-between'} sx={{ mb: 2 }}>
+        {[1, 2, 3, 4, 5].map((i) => (
+          <Box key={i} sx={{ textAlign: 'center' }}>
+            <Skeleton width={60} height={12} />
+            <Skeleton width={50} height={28} sx={{ mt: 0.5, mx: 'auto' }} />
+          </Box>
+        ))}
+      </Stack>
+      <Skeleton width="100%" height={14} />
+      <Skeleton width="80%" height={14} sx={{ mt: 0.5 }} />
+    </Box>
+
+    {/* Right */}
+    <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+      {[1, 2, 3].map((i) => (
+        <Skeleton key={i} variant="rounded" width={132} height={188} sx={{ borderRadius: 1.5 }} />
+      ))}
+    </Stack>
+  </Box>
+);
+
+// ─── Empty State ──────────────────────────────────────────────────────────────
+
+const EmptyState = () => (
+  <Box
+    sx={{
+      textAlign: 'center',
+      py: 8,
+      px: 3,
+    }}
+  >
+    <Typography variant="h6" sx={{ color: 'text.secondary', mb: 1 }}>
+      No creators found
+    </Typography>
+    <Typography variant="body2" sx={{ color: 'text.disabled' }}>
+      Try adjusting your filters to see more results.
+    </Typography>
+  </Box>
+);
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
+const CreatorList = ({ creators, isLoading, isError, pagination, selectedIds, onSelect }) => {
+  if (isError) {
+    return (
+      <Box sx={{ textAlign: 'center', py: 6 }}>
+        <Typography sx={{ color: 'error.main', fontSize: 15 }}>
+          Failed to fetch creators. Please try again.
+        </Typography>
+      </Box>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <Box sx={{ mt: 3, border: '1px solid', borderColor: 'divider', overflow: 'hidden' }}>
+        {[1, 2, 3, 4].map((i) => (
+          <Box key={i}>
+            {i > 1 && <Divider />}
+            <CreatorCardSkeleton />
+          </Box>
+        ))}
+      </Box>
+    );
+  }
+
+  if (!creators || creators.length === 0) {
+    return <EmptyState />;
+  }
+
+  return (
+    <Box sx={{ mt: 3 }}>
+      {/* Result count */}
+      <Typography sx={{ mb: 2, fontSize: 14, color: 'text.secondary' }}>
+        Showing {creators.length}
+        {pagination ? ` of ${pagination.total} creator${creators.length !== 1 ? 's' : ''}`  : ''}
+      </Typography>
+
+      {/* Creator rows */}
+      <Box
+        sx={{
+          border: '1px solid',
+          borderColor: 'divider',
+          overflow: 'hidden',
+        }}
+      >
+        {creators.map((creator, index) => {
+          const rowKey = creator.rowId || `${creator.userId}-${creator.platform || index}`;
+
+          return (
+          <Box key={rowKey}>
+            {index > 0 && <Divider />}
+            <CreatorCard
+              creator={creator}
+              selected={selectedIds?.includes(rowKey)}
+              onSelect={onSelect}
+            />
+          </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+};
+
+CreatorList.propTypes = {
+  creators: PropTypes.array,
+  isLoading: PropTypes.bool,
+  isError: PropTypes.any,
+  pagination: PropTypes.shape({
+    page: PropTypes.number,
+    limit: PropTypes.number,
+    total: PropTypes.number,
+  }),
+  selectedIds: PropTypes.arrayOf(PropTypes.string),
+  onSelect: PropTypes.func,
+};
+
+CreatorList.defaultProps = {
+  creators: [],
+  isLoading: false,
+  isError: null,
+  pagination: null,
+  selectedIds: [],
+  onSelect: undefined,
+};
+
+export default CreatorList;

--- a/src/sections/discovery-tool/components/CreatorList.jsx
+++ b/src/sections/discovery-tool/components/CreatorList.jsx
@@ -102,12 +102,6 @@ const CreatorList = ({ creators, isLoading, isError, pagination, selectedIds, on
 
   return (
     <Box sx={{ mt: 3 }}>
-      {/* Result count */}
-      <Typography sx={{ mb: 2, fontSize: 14, color: 'text.secondary' }}>
-        Showing {creators.length}
-        {pagination ? ` of ${pagination.total} creator${creators.length !== 1 ? 's' : ''}`  : ''}
-      </Typography>
-
       {/* Creator rows */}
       <Box
         sx={{

--- a/src/sections/discovery-tool/components/CreatorList.jsx
+++ b/src/sections/discovery-tool/components/CreatorList.jsx
@@ -30,7 +30,7 @@ const CreatorCardSkeleton = () => (
 
     {/* Middle */}
     <Box sx={{ flex: 1 }}>
-      <Stack direction="row" justifyContent={'space-between'} sx={{ mb: 2 }}>
+      <Stack direction="row" justifyContent="space-between" sx={{ mb: 2 }}>
         {[1, 2, 3, 4, 5].map((i) => (
           <Box key={i} sx={{ textAlign: 'center' }}>
             <Skeleton width={60} height={12} />

--- a/src/sections/discovery-tool/components/CreatorList.jsx
+++ b/src/sections/discovery-tool/components/CreatorList.jsx
@@ -101,7 +101,7 @@ const CreatorList = ({ creators, isLoading, isError, pagination, selectedIds, on
   }
 
   return (
-    <Box sx={{ mt: 3 }}>
+    <Box sx={{ mt: 2 }}>
       {/* Creator rows */}
       <Box
         sx={{

--- a/src/sections/discovery-tool/components/CreatorList.jsx
+++ b/src/sections/discovery-tool/components/CreatorList.jsx
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 
-import { Box, Stack, Divider, Skeleton, Typography } from '@mui/material';
+import { Box, Stack, Button, Divider, Skeleton, Typography } from '@mui/material';
+
+import Iconify from 'src/components/iconify';
 
 import CreatorCard from './CreatorCard';
 
@@ -13,11 +15,19 @@ const CreatorCardSkeleton = () => (
       flexDirection: 'row',
       alignItems: 'center',
       gap: 2,
-      p: 1
+      p: 1,
     }}
   >
     {/* Left */}
-    <Box sx={{ width: 188, display: 'flex', flexDirection: 'column', alignItems: 'center', borderColor: 'divider' }}>
+    <Box
+      sx={{
+        width: 188,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        borderColor: 'divider',
+      }}
+    >
       <Skeleton variant="circular" width={72} height={72} />
       <Skeleton width={100} height={18} sx={{ mt: 1 }} />
       <Skeleton width={80} height={14} sx={{ mt: 0.5 }} />
@@ -72,7 +82,15 @@ const EmptyState = () => (
 
 // ─── Main Component ───────────────────────────────────────────────────────────
 
-const CreatorList = ({ creators, isLoading, isError, pagination, selectedIds, onSelect }) => {
+const CreatorList = ({
+  creators,
+  isLoading,
+  isError,
+  pagination,
+  selectedIds,
+  onSelect,
+  onCompare,
+}) => {
   if (isError) {
     return (
       <Box sx={{ textAlign: 'center', py: 6 }}>
@@ -100,8 +118,47 @@ const CreatorList = ({ creators, isLoading, isError, pagination, selectedIds, on
     return <EmptyState />;
   }
 
+  // Compute viewedCount and total for results info
+  const total = pagination?.total ?? creators.length;
+  const viewedCount = pagination?.limit && pagination?.page
+    ? Math.min(pagination.page * pagination.limit, total)
+    : creators.length;
+
   return (
-    <Box sx={{ mt: 2 }}>
+    <Box sx={{ mt: 4 }}>
+      <Box sx={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', mb: 1.5, gap: 2 }}>
+        <Typography sx={{ fontSize: 14, color: 'text.secondary', mr: 2 }}>
+          {`${viewedCount} of ${total} creator${total === 1 ? '' : 's'}`}
+        </Typography>
+        <Button
+          onClick={() => onCompare?.(selectedIds)}
+          disabled={selectedIds?.length !== 2}
+          sx={{
+            color: '#231F20',
+            bgcolor: '#FFFFFF',
+            textTransform: 'none',
+            fontWeight: 600,
+            fontSize: 14,
+            pb: 1,
+            borderRadius: 1,
+            border: '1px solid #E7E7E7',
+            boxShadow: '0px -3px 0px 0px #E7E7E7 inset',
+            '&:hover': {
+              bgcolor: 'rgba(0, 0, 0, 0.03)',
+              border: '1px solid #E7E7E7',
+              boxShadow: '0px -3px 0px 0px #E7E7E7 inset',
+            },
+            ':disabled': {
+              bgcolor: 'rgba(0, 0, 0, 0.05)',
+              border: '1px solid rgba(0, 0, 0, 0.05)',
+              boxShadow: '0px -3px 0px 0px rgba(0, 0, 0, 0.05) inset'
+            }
+          }}
+        >
+          Compare Creators
+        </Button>
+      </Box>
+
       {/* Creator rows */}
       <Box
         sx={{
@@ -114,14 +171,14 @@ const CreatorList = ({ creators, isLoading, isError, pagination, selectedIds, on
           const rowKey = creator.rowId || `${creator.userId}-${creator.platform || index}`;
 
           return (
-          <Box key={rowKey}>
-            {index > 0 && <Divider />}
-            <CreatorCard
-              creator={creator}
-              selected={selectedIds?.includes(rowKey)}
-              onSelect={onSelect}
-            />
-          </Box>
+            <Box key={rowKey}>
+              {index > 0 && <Divider />}
+              <CreatorCard
+                creator={creator}
+                selected={selectedIds?.includes(rowKey)}
+                onSelect={onSelect}
+              />
+            </Box>
           );
         })}
       </Box>
@@ -140,6 +197,7 @@ CreatorList.propTypes = {
   }),
   selectedIds: PropTypes.arrayOf(PropTypes.string),
   onSelect: PropTypes.func,
+  onCompare: PropTypes.func,
 };
 
 CreatorList.defaultProps = {
@@ -149,6 +207,7 @@ CreatorList.defaultProps = {
   pagination: null,
   selectedIds: [],
   onSelect: undefined,
+  onCompare: undefined,
 };
 
 export default CreatorList;

--- a/src/sections/discovery-tool/components/DiscoveryFilterBar.jsx
+++ b/src/sections/discovery-tool/components/DiscoveryFilterBar.jsx
@@ -17,6 +17,7 @@ import { interestsLists } from 'src/contants/interestLists';
 
 import Iconify from 'src/components/iconify';
 
+import FilterPills from './FilterPills';
 import {
   GENDERS,
   PLATFORMS,
@@ -25,8 +26,6 @@ import {
   filterReducer,
   FILTER_INITIAL_STATE,
 } from '../constants';
-
-import FilterPills from './FilterPills';
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
@@ -363,11 +362,15 @@ const DiscoveryFilterBar = React.memo(({ onFiltersChange, availableLocations, re
               boxShadow: '0px -3px 0px 0px #00000073 inset'
             }}
           >
-            {isCountLoading
-              ? 'Searching creators...'
-              : resultCount != null
-              ? `Show ${resultCount} Creator${resultCount !== 1 ? 's' : ''}`
-              : 'Show Results'}
+            {(() => {
+              if (isCountLoading) {
+                return 'Searching creators...';
+              }
+              if (resultCount != null) {
+                return `Show ${resultCount} Creator${resultCount !== 1 ? 's' : ''}`;
+              }
+              return 'Show Results';
+            })()}
           </Button>
         )}
       </Stack>

--- a/src/sections/discovery-tool/components/DiscoveryFilterBar.jsx
+++ b/src/sections/discovery-tool/components/DiscoveryFilterBar.jsx
@@ -258,6 +258,11 @@ const DiscoveryFilterBar = React.memo(({ onFiltersChange, availableLocations, re
           fullWidth
           popupIcon={<Iconify icon="line-md:chevron-down" width={21} height={21} color="#231F20" />}
           renderInput={(params) => <TextField {...params} placeholder="Creator Country" />}
+          ListboxProps={{
+            style: {
+              maxHeight: 500
+            }
+          }}
         />
 
         {/* City */}
@@ -334,7 +339,7 @@ const DiscoveryFilterBar = React.memo(({ onFiltersChange, availableLocations, re
           }}
         >
           {CREDIT_TIERS.map((opt) => (
-            <MenuItem key={opt.value} value={opt.value}>
+            <MenuItem key={opt.value} value={opt.value} sx={{ height: 50 }}>
               {opt.label}
             </MenuItem>
           ))}

--- a/src/sections/discovery-tool/components/DiscoveryFilterBar.jsx
+++ b/src/sections/discovery-tool/components/DiscoveryFilterBar.jsx
@@ -1,0 +1,305 @@
+import PropTypes from 'prop-types';
+import React, { useMemo, useEffect, useReducer, useCallback } from 'react';
+
+import {
+  Box,
+  Stack,
+  Select,
+  Button,
+  MenuItem,
+  InputBase,
+  TextField,
+  Typography,
+  Autocomplete,
+  InputAdornment,
+} from '@mui/material';
+
+import { interestsLists } from 'src/contants/interestLists';
+
+import Iconify from 'src/components/iconify';
+
+import {
+  GENDERS,
+  selectSx,
+  PLATFORMS,
+  AGE_RANGES,
+  CREDIT_TIERS,
+  filterReducer,
+  FILTER_INITIAL_STATE,
+} from '../constants';
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+const DiscoveryFilterBar = React.memo(({ onFiltersChange, availableLocations }) => {
+  const [state, dispatch] = useReducer(filterReducer, FILTER_INITIAL_STATE);
+
+  // Debounce keyword → debouncedKeyword
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      dispatch({ type: 'SET_DEBOUNCED_KEYWORD', payload: state.keyword });
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [state.keyword]);
+
+  // Notify parent whenever relevant filter state changes
+  useEffect(() => {
+    onFiltersChange({
+      platform: state.platform,
+      debouncedKeyword: state.debouncedKeyword,
+      ageRange: state.ageRange,
+      country: state.country,
+      city: state.city,
+      gender: state.gender,
+      creditTier: state.creditTier,
+      interests: state.interests,
+    });
+  }, [
+    state.platform,
+    state.debouncedKeyword,
+    state.ageRange,
+    state.country,
+    state.city,
+    state.gender,
+    state.creditTier,
+    state.interests,
+    onFiltersChange,
+  ]);
+
+  // Derive location options from the available locations returned by the API
+  const countryOptions = useMemo(() => Object.keys(availableLocations || {}), [availableLocations]);
+  const cityOptions = useMemo(
+    () => (state.country && availableLocations ? availableLocations[state.country] || [] : []),
+    [state.country, availableLocations]
+  );
+
+  // Check if any filter is active (for showing Clear All)
+  const hasActiveFilters = useMemo(
+    () =>
+      state.platform !== 'all' ||
+      state.keyword !== '' ||
+      state.ageRange !== '' ||
+      state.country !== null ||
+      state.city !== null ||
+      state.gender !== '' ||
+      state.creditTier !== '' ||
+      state.interests.length > 0,
+    [state]
+  );
+
+  // ─── Handlers ─────────────────────────────────────────────────────────────
+
+  const handlePlatform = useCallback((e) => {
+    dispatch({ type: 'SET_PLATFORM', payload: e.target.value });
+  }, []);
+
+  const handleKeyword = useCallback((e) => {
+    dispatch({ type: 'SET_KEYWORD', payload: e.target.value });
+  }, []);
+
+  const handleAgeRange = useCallback((e) => {
+    dispatch({ type: 'SET_AGE_RANGE', payload: e.target.value });
+  }, []);
+
+  const handleGender = useCallback((e) => {
+    dispatch({ type: 'SET_GENDER', payload: e.target.value });
+  }, []);
+
+  const handleCreditTier = useCallback((e) => {
+    dispatch({ type: 'SET_CREDIT_TIER', payload: e.target.value });
+  }, []);
+
+  const handleCountry = useCallback((_e, value) => {
+    dispatch({ type: 'SET_COUNTRY', payload: value });
+  }, []);
+
+  const handleCity = useCallback((_e, value) => {
+    dispatch({ type: 'SET_CITY', payload: value });
+  }, []);
+
+  const handleInterests = useCallback((_e, value) => {
+    dispatch({ type: 'SET_INTERESTS', payload: value });
+  }, []);
+
+  const handleClearAll = useCallback(() => {
+    dispatch({ type: 'CLEAR_ALL' });
+  }, []);
+
+  // ─── Render ───────────────────────────────────────────────────────────────
+
+  return (
+    <Box sx={{ mt: 3 }}>
+      {/* Row 1: Search + Platform */}
+      <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap" sx={{ mb: 2 }}>
+        {/* Keyword search */}
+        <Box
+          sx={{
+            flex: 1,
+            minWidth: 250,
+            border: '1px solid',
+            borderColor: 'divider',
+            borderRadius: 1,
+            display: 'flex',
+            alignItems: 'center',
+            px: 1.5,
+            py: 0.5,
+          }}
+        >
+          <InputAdornment position="start">
+            <Iconify icon="eva:search-fill" sx={{ color: 'text.disabled', mr: 1 }} />
+          </InputAdornment>
+          <InputBase
+            fullWidth
+            value={state.keyword}
+            onChange={handleKeyword}
+            placeholder="Search by caption keyword..."
+            sx={{ fontSize: 14 }}
+          />
+        </Box>
+
+        {/* Platform */}
+        <Select
+          value={state.platform}
+          onChange={handlePlatform}
+          size="small"
+          displayEmpty
+          sx={selectSx}
+        >
+          {PLATFORMS.map((opt) => (
+            <MenuItem key={opt.value} value={opt.value}>
+              {opt.label}
+            </MenuItem>
+          ))}
+        </Select>
+      </Stack>
+
+      {/* Row 2: All other filters */}
+      <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap" useFlexGap>
+        {/* Gender */}
+        <Select
+          value={state.gender}
+          onChange={handleGender}
+          size="small"
+          displayEmpty
+          sx={selectSx}
+          renderValue={(selected) => {
+            if (!selected) return <Typography sx={{ color: 'text.disabled', fontSize: 14 }}>Gender</Typography>;
+            return selected;
+          }}
+        >
+          <MenuItem value="">
+            <em>All Genders</em>
+          </MenuItem>
+          {GENDERS.map((opt) => (
+            <MenuItem key={opt.value} value={opt.value}>
+              {opt.label}
+            </MenuItem>
+          ))}
+        </Select>
+
+        {/* Age Range */}
+        <Select
+          value={state.ageRange}
+          onChange={handleAgeRange}
+          size="small"
+          displayEmpty
+          sx={selectSx}
+          renderValue={(selected) => {
+            if (!selected) return <Typography sx={{ color: 'text.disabled', fontSize: 14 }}>Age Range</Typography>;
+            return selected;
+          }}
+        >
+          <MenuItem value="">
+            <em>All Ages</em>
+          </MenuItem>
+          {AGE_RANGES.map((opt) => (
+            <MenuItem key={opt.value} value={opt.value}>
+              {opt.label}
+            </MenuItem>
+          ))}
+        </Select>
+
+        {/* Credit Tier */}
+        <Select
+          value={state.creditTier}
+          onChange={handleCreditTier}
+          size="small"
+          displayEmpty
+          sx={selectSx}
+          renderValue={(selected) => {
+            if (!selected)
+              return <Typography sx={{ color: 'text.disabled', fontSize: 14 }}>Credit Tier</Typography>;
+            const tier = CREDIT_TIERS.find((t) => t.value === selected);
+            return tier ? tier.label : selected;
+          }}
+        >
+          <MenuItem value="">
+            <em>All Tiers</em>
+          </MenuItem>
+          {CREDIT_TIERS.map((opt) => (
+            <MenuItem key={opt.value} value={opt.value}>
+              {opt.label}
+            </MenuItem>
+          ))}
+        </Select>
+
+        {/* Country */}
+        <Autocomplete
+          value={state.country}
+          onChange={handleCountry}
+          options={countryOptions}
+          size="small"
+          sx={{ minWidth: 180 }}
+          renderInput={(params) => <TextField {...params} placeholder="Country" />}
+        />
+
+        {/* City */}
+        <Autocomplete
+          value={state.city}
+          onChange={handleCity}
+          options={cityOptions}
+          size="small"
+          disabled={!state.country}
+          sx={{ minWidth: 180 }}
+          renderInput={(params) => (
+            <TextField {...params} placeholder={state.country ? 'City' : 'Select country first'} />
+          )}
+        />
+
+        {/* Interests (multi-select) */}
+        <Autocomplete
+          multiple
+          value={state.interests}
+          onChange={handleInterests}
+          options={interestsLists}
+          size="small"
+          limitTags={2}
+          sx={{ minWidth: 250 }}
+          renderInput={(params) => <TextField {...params} placeholder="Interests" />}
+        />
+
+        {/* Clear All */}
+        {hasActiveFilters && (
+          <Button
+            variant="outlined"
+            color="inherit"
+            size="small"
+            onClick={handleClearAll}
+            startIcon={<Iconify icon="solar:trash-bin-minimalistic-bold" />}
+            sx={{ whiteSpace: 'nowrap', flexShrink: 0 }}
+          >
+            Clear All
+          </Button>
+        )}
+      </Stack>
+    </Box>
+  );
+});
+
+DiscoveryFilterBar.displayName = 'DiscoveryFilterBar';
+
+DiscoveryFilterBar.propTypes = {
+  onFiltersChange: PropTypes.func.isRequired,
+  availableLocations: PropTypes.object,
+};
+
+export default DiscoveryFilterBar;

--- a/src/sections/discovery-tool/components/DiscoveryFilterBar.jsx
+++ b/src/sections/discovery-tool/components/DiscoveryFilterBar.jsx
@@ -41,11 +41,20 @@ const DiscoveryFilterBar = React.memo(({ onFiltersChange, availableLocations }) 
     return () => clearTimeout(timer);
   }, [state.keyword]);
 
+  // Debounce hashtag → debouncedHashtag
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      dispatch({ type: 'SET_DEBOUNCED_HASHTAG', payload: state.hashtag });
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [state.hashtag]);
+
   // Notify parent whenever relevant filter state changes
   useEffect(() => {
     onFiltersChange({
       platform: state.platform,
       debouncedKeyword: state.debouncedKeyword,
+      debouncedHashtag: state.debouncedHashtag,
       ageRange: state.ageRange,
       country: state.country,
       city: state.city,
@@ -56,6 +65,7 @@ const DiscoveryFilterBar = React.memo(({ onFiltersChange, availableLocations }) 
   }, [
     state.platform,
     state.debouncedKeyword,
+    state.debouncedHashtag,
     state.ageRange,
     state.country,
     state.city,
@@ -77,6 +87,7 @@ const DiscoveryFilterBar = React.memo(({ onFiltersChange, availableLocations }) 
     () =>
       state.platform !== 'all' ||
       state.keyword !== '' ||
+      state.hashtag !== '' ||
       state.ageRange !== '' ||
       state.country !== null ||
       state.city !== null ||
@@ -94,6 +105,10 @@ const DiscoveryFilterBar = React.memo(({ onFiltersChange, availableLocations }) 
 
   const handleKeyword = useCallback((e) => {
     dispatch({ type: 'SET_KEYWORD', payload: e.target.value });
+  }, []);
+
+  const handleHashtag = useCallback((e) => {
+    dispatch({ type: 'SET_HASHTAG', payload: e.target.value });
   }, []);
 
   const handleAgeRange = useCallback((e) => {
@@ -130,6 +145,21 @@ const DiscoveryFilterBar = React.memo(({ onFiltersChange, availableLocations }) 
     <Box sx={{ mt: 3 }}>
       {/* Row 1: Search + Platform */}
       <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap" sx={{ mb: 2 }}>
+        {/* Platform */}
+        <Select
+          value={state.platform}
+          onChange={handlePlatform}
+          size="small"
+          displayEmpty
+          sx={selectSx}
+        >
+          {PLATFORMS.map((opt) => (
+            <MenuItem key={opt.value} value={opt.value}>
+              {opt.label}
+            </MenuItem>
+          ))}
+        </Select>
+
         {/* Keyword search */}
         <Box
           sx={{
@@ -156,24 +186,32 @@ const DiscoveryFilterBar = React.memo(({ onFiltersChange, availableLocations }) 
           />
         </Box>
 
-        {/* Platform */}
-        <Select
-          value={state.platform}
-          onChange={handlePlatform}
-          size="small"
-          displayEmpty
-          sx={selectSx}
+        {/* Hashtag search */}
+        <Box
+          sx={{
+            flex: 1,
+            minWidth: 250,
+            border: '1px solid',
+            borderColor: 'divider',
+            borderRadius: 1,
+            display: 'flex',
+            alignItems: 'center',
+            px: 1.5,
+            py: 0.5,
+          }}
         >
-          {PLATFORMS.map((opt) => (
-            <MenuItem key={opt.value} value={opt.value}>
-              {opt.label}
-            </MenuItem>
-          ))}
-        </Select>
-      </Stack>
+          <InputAdornment position="start">
+            <Iconify icon="mdi:tag-outline" sx={{ color: 'text.disabled', mr: 1 }} />
+          </InputAdornment>
+          <InputBase
+            fullWidth
+            value={state.hashtag}
+            onChange={handleHashtag}
+            placeholder="Search hashtags (e.g. #sport #fun)..."
+            sx={{ fontSize: 14 }}
+          />
+        </Box>
 
-      {/* Row 2: All other filters */}
-      <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap" useFlexGap>
         {/* Gender */}
         <Select
           value={state.gender}
@@ -186,9 +224,6 @@ const DiscoveryFilterBar = React.memo(({ onFiltersChange, availableLocations }) 
             return selected;
           }}
         >
-          <MenuItem value="">
-            <em>All Genders</em>
-          </MenuItem>
           {GENDERS.map((opt) => (
             <MenuItem key={opt.value} value={opt.value}>
               {opt.label}
@@ -208,16 +243,16 @@ const DiscoveryFilterBar = React.memo(({ onFiltersChange, availableLocations }) 
             return selected;
           }}
         >
-          <MenuItem value="">
-            <em>All Ages</em>
-          </MenuItem>
           {AGE_RANGES.map((opt) => (
             <MenuItem key={opt.value} value={opt.value}>
               {opt.label}
             </MenuItem>
           ))}
         </Select>
+      </Stack>
 
+      {/* Row 2: All other filters */}
+      <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap" useFlexGap>
         {/* Credit Tier */}
         <Select
           value={state.creditTier}
@@ -232,9 +267,6 @@ const DiscoveryFilterBar = React.memo(({ onFiltersChange, availableLocations }) 
             return tier ? tier.label : selected;
           }}
         >
-          <MenuItem value="">
-            <em>All Tiers</em>
-          </MenuItem>
           {CREDIT_TIERS.map((opt) => (
             <MenuItem key={opt.value} value={opt.value}>
               {opt.label}

--- a/src/sections/discovery-tool/components/DiscoveryFilterBar.jsx
+++ b/src/sections/discovery-tool/components/DiscoveryFilterBar.jsx
@@ -150,7 +150,7 @@ const DiscoveryFilterBar = React.memo(({ onFiltersChange, availableLocations, re
           }
         >
           {PLATFORMS.map((opt) => (
-            <MenuItem key={opt.value} value={opt.value}>
+            <MenuItem key={opt.value} value={opt.value} sx={{ height: 50 }}>
               {opt.label}
             </MenuItem>
           ))}
@@ -217,7 +217,7 @@ const DiscoveryFilterBar = React.memo(({ onFiltersChange, availableLocations, re
           }}
         >
           {GENDERS.map((opt) => (
-            <MenuItem key={opt.value} value={opt.value}>
+            <MenuItem key={opt.value} value={opt.value} sx={{ height: 50 }}>
               {opt.label}
             </MenuItem>
           ))}
@@ -240,7 +240,7 @@ const DiscoveryFilterBar = React.memo(({ onFiltersChange, availableLocations, re
           }}
         >
           {AGE_RANGES.map((opt) => (
-            <MenuItem key={opt.value} value={opt.value}>
+            <MenuItem key={opt.value} value={opt.value} sx={{ height: 50 }}>
               {opt.label}
             </MenuItem>
           ))}
@@ -292,6 +292,11 @@ const DiscoveryFilterBar = React.memo(({ onFiltersChange, availableLocations, re
               whiteSpace: 'nowrap',
             },
           }}
+          MenuProps={{
+            style: {
+              maxHeight: 500
+            }
+          }}  
           IconComponent={() => null}
           endAdornment={
             <Iconify icon="line-md:chevron-down" width={30} height={30} color="#231F20" />
@@ -304,7 +309,7 @@ const DiscoveryFilterBar = React.memo(({ onFiltersChange, availableLocations, re
           }}
         >
           {interestsLists.map((interest) => (
-            <MenuItem key={interest} value={interest}>
+            <MenuItem key={interest} value={interest} sx={{ height: 50 }}>
               {interest}
             </MenuItem>
           ))}

--- a/src/sections/discovery-tool/components/FilterPills.jsx
+++ b/src/sections/discovery-tool/components/FilterPills.jsx
@@ -1,0 +1,132 @@
+import PropTypes from 'prop-types';
+
+import { Chip, Stack } from '@mui/material';
+
+import Iconify from 'src/components/iconify';
+
+import { PLATFORMS, CREDIT_TIERS } from '../constants';
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+const FilterPills = ({ filters, onRemoveFilter }) => {
+  const pills = [];
+
+  if (filters.platform && filters.platform !== 'all') {
+    const platform = PLATFORMS.find((p) => p.value === filters.platform);
+    pills.push({
+      key: 'platform',
+      label: platform ? platform.label : filters.platform,
+      onRemove: () => onRemoveFilter('SET_PLATFORM', 'all'),
+    });
+  }
+
+  if (filters.keyword) {
+    pills.push({
+      key: 'keyword',
+      label: `Keyword: "${filters.keyword}"`,
+      onRemove: () => onRemoveFilter('SET_KEYWORD', ''),
+    });
+  }
+
+  if (filters.hashtag) {
+    pills.push({
+      key: 'hashtag',
+      label: `Hashtag: "${filters.hashtag}"`,
+      onRemove: () => onRemoveFilter('SET_HASHTAG', ''),
+    });
+  }
+
+  if (filters.gender) {
+    pills.push({
+      key: 'gender',
+      label: `Gender: ${filters.gender}`,
+      onRemove: () => onRemoveFilter('SET_GENDER', ''),
+    });
+  }
+
+  if (filters.ageRange) {
+    pills.push({
+      key: 'ageRange',
+      label: `Age: ${filters.ageRange}`,
+      onRemove: () => onRemoveFilter('SET_AGE_RANGE', ''),
+    });
+  }
+
+  if (filters.country) {
+    pills.push({
+      key: 'country',
+      label: `Country: ${filters.country}`,
+      onRemove: () => onRemoveFilter('SET_COUNTRY', null),
+    });
+  }
+
+  if (filters.city) {
+    pills.push({
+      key: 'city',
+      label: `City: ${filters.city}`,
+      onRemove: () => onRemoveFilter('SET_CITY', null),
+    });
+  }
+
+  if (filters.creditTier) {
+    const tier = CREDIT_TIERS.find((t) => t.value === filters.creditTier);
+    pills.push({
+      key: 'creditTier',
+      label: tier ? `Credit Tier: ${tier.label}` : filters.creditTier,
+      onRemove: () => onRemoveFilter('SET_CREDIT_TIER', ''),
+    });
+  }
+
+  if (filters.interests.length > 0) {
+    pills.push({
+      key: 'interests',
+      label: `Interests: ${filters.interests.join(', ')}`,
+      onRemove: () => onRemoveFilter('SET_INTERESTS', []),
+    });
+  }
+
+  if (pills.length === 0) return null;
+
+  return (
+    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap mb={1}>
+      {pills.map((pill) => (
+        <Chip
+          key={pill.key}
+          label={pill.label}
+          onDelete={pill.onRemove}
+          deleteIcon={<Iconify icon="mingcute:close-line" width={12} />}
+          size="small"
+					variant='outline'
+          sx={{
+						px: 0.5,
+						py: 1.6,
+						bgcolor: '#D9D9D9',
+						color: '#231F20',
+							borderRadius: 2,
+							fontSize: 13,
+							'& .MuiChip-deleteIcon': {
+								marginLeft: 2,
+							},
+          }}
+        />
+      ))}
+    </Stack>
+  );
+};
+
+FilterPills.propTypes = {
+  filters: PropTypes.shape({
+    platform: PropTypes.string,
+    keyword: PropTypes.string,
+    hashtag: PropTypes.string,
+    gender: PropTypes.string,
+    ageRange: PropTypes.string,
+    country: PropTypes.string,
+    city: PropTypes.string,
+    creditTier: PropTypes.string,
+    interests: PropTypes.arrayOf(PropTypes.string),
+  }).isRequired,
+  onRemoveFilter: PropTypes.func.isRequired,
+};
+
+export default FilterPills;

--- a/src/sections/discovery-tool/components/index.js
+++ b/src/sections/discovery-tool/components/index.js
@@ -1,0 +1,1 @@
+export { default as DiscoveryFilterBar } from './DiscoveryFilterBar';

--- a/src/sections/discovery-tool/components/index.js
+++ b/src/sections/discovery-tool/components/index.js
@@ -1,1 +1,4 @@
 export { default as DiscoveryFilterBar } from './DiscoveryFilterBar';
+export { default as FilterPills } from './FilterPills';
+export { default as CreatorCard } from './CreatorCard';
+export { default as CreatorList } from './CreatorList';

--- a/src/sections/discovery-tool/components/index.js
+++ b/src/sections/discovery-tool/components/index.js
@@ -1,4 +1,4 @@
-export { default as DiscoveryFilterBar } from './DiscoveryFilterBar';
 export { default as FilterPills } from './FilterPills';
 export { default as CreatorCard } from './CreatorCard';
 export { default as CreatorList } from './CreatorList';
+export { default as DiscoveryFilterBar } from './DiscoveryFilterBar';

--- a/src/sections/discovery-tool/constants.js
+++ b/src/sections/discovery-tool/constants.js
@@ -90,17 +90,3 @@ export const filterReducer = (state, action) => {
       return state;
   }
 };
-
-// ─── Shared select styles ─────────────────────────────────────────────────────
-
-export const selectSx = {
-  minWidth: 160,
-  '& .MuiInputBase-input': {
-    py: 1,
-    px: 1.5,
-    fontSize: 14,
-  },
-  border: '1px solid',
-  borderColor: 'divider',
-  borderRadius: 1,
-};

--- a/src/sections/discovery-tool/constants.js
+++ b/src/sections/discovery-tool/constants.js
@@ -1,0 +1,84 @@
+// ─── Discovery Tool Filter Constants ──────────────────────────────────────────
+
+export const AGE_RANGES = [
+  { value: '18-24', label: '18–24' },
+  { value: '25-34', label: '25–34' },
+  { value: '35-44', label: '35–44' },
+  { value: '45-54', label: '45–54' },
+];
+
+export const GENDERS = [
+  { value: 'Male', label: 'Male' },
+  { value: 'Female', label: 'Female' },
+  { value: 'Non-Binary', label: 'Non-Binary' },
+];
+
+export const CREDIT_TIERS = [
+  { value: 'Nano A', label: 'Nano A (0K – 5K)' },
+  { value: 'Nano B', label: 'Nano B (5K – 15K)' },
+  { value: 'Micro A', label: 'Micro A (15K – 30K)' },
+  { value: 'Micro B', label: 'Micro B (30K – 50K)' },
+  { value: 'Micro C', label: 'Micro C (50K – 100K)' },
+  { value: 'Macro', label: 'Macro (100K – 500K)' },
+];
+
+export const PLATFORMS = [
+  { value: 'all', label: 'All Platforms' },
+  { value: 'instagram', label: 'Instagram' },
+  { value: 'tiktok', label: 'TikTok' },
+];
+
+// ─── Filter initial state & reducer ──────────────────────────────────────────
+
+export const FILTER_INITIAL_STATE = {
+  platform: 'all',
+  keyword: '',
+  debouncedKeyword: '',
+  ageRange: '',
+  country: null,
+  city: null,
+  gender: '',
+  creditTier: '',
+  interests: [],
+};
+
+export const filterReducer = (state, action) => {
+  switch (action.type) {
+    case 'SET_PLATFORM':
+      return { ...state, platform: action.payload };
+    case 'SET_KEYWORD':
+      return { ...state, keyword: action.payload };
+    case 'SET_DEBOUNCED_KEYWORD':
+      return { ...state, debouncedKeyword: action.payload };
+    case 'SET_AGE_RANGE':
+      return { ...state, ageRange: action.payload };
+    case 'SET_COUNTRY':
+      return { ...state, country: action.payload, city: null };
+    case 'SET_CITY':
+      return { ...state, city: action.payload };
+    case 'SET_GENDER':
+      return { ...state, gender: action.payload };
+    case 'SET_CREDIT_TIER':
+      return { ...state, creditTier: action.payload };
+    case 'SET_INTERESTS':
+      return { ...state, interests: action.payload };
+    case 'CLEAR_ALL':
+      return { ...FILTER_INITIAL_STATE };
+    default:
+      return state;
+  }
+};
+
+// ─── Shared select styles ─────────────────────────────────────────────────────
+
+export const selectSx = {
+  minWidth: 160,
+  '& .MuiInputBase-input': {
+    py: 1,
+    px: 1.5,
+    fontSize: 14,
+  },
+  border: '1px solid',
+  borderColor: 'divider',
+  borderRadius: 1,
+};

--- a/src/sections/discovery-tool/constants.js
+++ b/src/sections/discovery-tool/constants.js
@@ -34,6 +34,8 @@ export const FILTER_INITIAL_STATE = {
   platform: 'all',
   keyword: '',
   debouncedKeyword: '',
+  hashtag: '',
+  debouncedHashtag: '',
   ageRange: '',
   country: null,
   city: null,
@@ -45,22 +47,42 @@ export const FILTER_INITIAL_STATE = {
 export const filterReducer = (state, action) => {
   switch (action.type) {
     case 'SET_PLATFORM':
+      if (state.platform === action.payload) return state;
       return { ...state, platform: action.payload };
     case 'SET_KEYWORD':
+      if (state.keyword === action.payload) return state;
       return { ...state, keyword: action.payload };
     case 'SET_DEBOUNCED_KEYWORD':
+      if (state.debouncedKeyword === action.payload) return state;
       return { ...state, debouncedKeyword: action.payload };
+    case 'SET_HASHTAG':
+      if (state.hashtag === action.payload) return state;
+      return { ...state, hashtag: action.payload };
+    case 'SET_DEBOUNCED_HASHTAG':
+      if (state.debouncedHashtag === action.payload) return state;
+      return { ...state, debouncedHashtag: action.payload };
     case 'SET_AGE_RANGE':
+      if (state.ageRange === action.payload) return state;
       return { ...state, ageRange: action.payload };
     case 'SET_COUNTRY':
+      if (state.country === action.payload && state.city === null) return state;
       return { ...state, country: action.payload, city: null };
     case 'SET_CITY':
+      if (state.city === action.payload) return state;
       return { ...state, city: action.payload };
     case 'SET_GENDER':
+      if (state.gender === action.payload) return state;
       return { ...state, gender: action.payload };
     case 'SET_CREDIT_TIER':
+      if (state.creditTier === action.payload) return state;
       return { ...state, creditTier: action.payload };
     case 'SET_INTERESTS':
+      if (
+        state.interests.length === action.payload.length &&
+        state.interests.every((value, index) => value === action.payload[index])
+      ) {
+        return state;
+      }
       return { ...state, interests: action.payload };
     case 'CLEAR_ALL':
       return { ...FILTER_INITIAL_STATE };

--- a/src/sections/discovery-tool/view/compare-creators-dialog.jsx
+++ b/src/sections/discovery-tool/view/compare-creators-dialog.jsx
@@ -1,0 +1,381 @@
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+
+import { Box, Chip, Stack, Avatar, Dialog, IconButton, Typography } from '@mui/material';
+
+import { formatNumber } from 'src/utils/socialMetricsCalculator';
+
+import Iconify from 'src/components/iconify';
+
+// ─── Helpers (shared with CreatorCard) ────────────────────────────────────────
+
+const formatEngagementRate = (rate) => {
+  if (!rate && rate !== 0) return '0%';
+  return `${Number(rate).toFixed(2)}%`;
+};
+
+const resolvePlatformData = (creator) => {
+  if (creator.platform === 'instagram' && creator.instagram?.connected) {
+    return { platform: 'instagram', ...creator.instagram };
+  }
+  if (creator.platform === 'tiktok' && creator.tiktok?.connected) {
+    return { platform: 'tiktok', ...creator.tiktok };
+  }
+  const ig = creator.instagram;
+  const tt = creator.tiktok;
+  if (ig?.connected && tt?.connected) {
+    return ig.followers >= tt.followers
+      ? { platform: 'instagram', ...ig }
+      : { platform: 'tiktok', ...tt };
+  }
+  if (ig?.connected) return { platform: 'instagram', ...ig };
+  if (tt?.connected) return { platform: 'tiktok', ...tt };
+  return { platform: null };
+};
+
+const getPlatformHandle = (creator, platform) => {
+  if (platform === 'instagram')
+    return creator.handles?.instagram ? `${creator.handles.instagram}` : null;
+  if (platform === 'tiktok') return creator.handles?.tiktok ? `${creator.handles.tiktok}` : null;
+  return null;
+};
+
+const getPlatformIcon = (platform) => {
+  if (platform === 'instagram') return 'mdi:instagram';
+  if (platform === 'tiktok') return 'ic:baseline-tiktok';
+  return null;
+};
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+const StatItem = ({ label, value }) => (
+  <Box sx={{ textAlign: 'center' }}>
+    <Typography variant="caption" sx={{ color: '#1340FF', fontWeight: 700 }}>
+      {label}
+    </Typography>
+    <Typography
+      variant="h4"
+      sx={{
+        fontWeight: 400,
+        fontFamily: 'Instrument Serif',
+        color: '#1340FF',
+        justifySelf: 'flex-start',
+      }}
+    >
+      {value}
+    </Typography>
+  </Box>
+);
+
+StatItem.propTypes = {
+  label: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+};
+
+const VideoThumbnail = ({ video, platform, tiktokHandle }) => {
+  const [hasImageError, setHasImageError] = useState(false);
+
+  const thumbnailUrl =
+    platform === 'instagram' ? video.thumbnail_url || video.media_url : video.cover_image_url;
+  const likes = video.like_count ?? 0;
+  const comments = platform === 'instagram' ? video.comments_count : video.comment_count;
+
+  const normalizedTiktokHandle = tiktokHandle ? String(tiktokHandle).replace(/^@/, '') : null;
+  const tiktokCanonicalUrl =
+    video.video_url ||
+    (normalizedTiktokHandle && video.video_id
+      ? `https://www.tiktok.com/@${normalizedTiktokHandle}/video/${video.video_id}`
+      : null);
+  const permalink =
+    platform === 'instagram' ? video.permalink : tiktokCanonicalUrl || video.embed_link;
+
+  return (
+    <Box
+      component={permalink ? 'a' : 'div'}
+      href={permalink || undefined}
+      target={permalink ? '_blank' : undefined}
+      rel={permalink ? 'noopener noreferrer' : undefined}
+      sx={{
+        position: 'relative',
+        flex: 1,
+        height: 220,
+        overflow: 'hidden',
+        cursor: permalink ? 'pointer' : 'default',
+        textDecoration: 'none',
+        '&:hover .thumbnail-overlay': { opacity: 1 },
+      }}
+    >
+      {thumbnailUrl && !hasImageError ? (
+        <Box
+          component="img"
+          src={thumbnailUrl}
+          alt="Video thumbnail"
+          sx={{ width: '100%', height: '100%', objectFit: 'cover' }}
+          onError={() => setHasImageError(true)}
+        />
+      ) : (
+        <Box
+          sx={{
+            width: '100%',
+            height: '100%',
+            bgcolor: 'grey.200',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <Iconify icon="mdi:video-outline" width={32} color="grey.500" />
+        </Box>
+      )}
+
+      {/* Stats overlay */}
+      <Box
+        sx={{
+          position: 'absolute',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          background: 'linear-gradient(transparent, rgba(0,0,0,0.6))',
+          px: 1,
+          py: 0.75,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1.5,
+        }}
+      >
+        <Stack direction="row" alignItems="center" spacing={0.5}>
+          <Iconify icon="mdi:heart-outline" width={20} color="#fff" />
+          <Typography sx={{ color: '#fff', fontSize: 11, fontWeight: 600 }}>
+            {formatNumber(likes || 0)}
+          </Typography>
+        </Stack>
+        <Stack direction="row" alignItems="center" spacing={0.5}>
+          <Iconify icon="tabler:message-circle" width={20} color="#fff" />
+          <Typography sx={{ color: '#fff', fontSize: 11, fontWeight: 600 }}>
+            {formatNumber(comments || 0)}
+          </Typography>
+        </Stack>
+      </Box>
+    </Box>
+  );
+};
+
+VideoThumbnail.propTypes = {
+  video: PropTypes.object.isRequired,
+  platform: PropTypes.oneOf(['instagram', 'tiktok']).isRequired,
+  tiktokHandle: PropTypes.string,
+};
+
+// ─── Single Creator Column ────────────────────────────────────────────────────
+
+const CreatorColumn = ({ creator }) => {
+  const platformData = resolvePlatformData(creator);
+  const { platform } = platformData;
+  const handle = getPlatformHandle(creator, platform);
+  const platformIcon = getPlatformIcon(platform);
+
+  const profilePicture =
+    platform === 'instagram'
+      ? creator.instagram?.profilePictureUrl || null
+      : creator.tiktok?.profilePictureUrl || null;
+  const bio =
+    platform === 'tiktok'
+      ? creator.tiktok?.biography || creator.about || null
+      : creator.instagram?.biography || creator.about || null;
+
+  const followers = platformData.followers || 0;
+  const engagementRate = platformData.engagementRate || 0;
+  const avgLikes = platformData.averageLikes || 0;
+  const avgSaves = platformData.averageSaves || 0;
+  const avgShares = platformData.averageShares || 0;
+
+  const topVideos = (platformData.topVideos || []).slice(0, 3);
+
+  return (
+    <Box
+      sx={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+      }}
+    >
+      {/* ─── User Card ───────────────────────────────────────────────────────── */}
+      <Box
+        sx={{
+          width: 250,
+          p: 2,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          bgcolor: '#F5F5F5',
+          borderRadius: 2,
+          boxShadow: '3px 3px 3px 2px rgba(0,0,0,0.5)',
+        }}
+      >
+        <Avatar src={profilePicture} alt={creator.name} sx={{ width: 72, height: 72, mb: 1.5 }} />
+        <Typography sx={{ fontWeight: 600, fontSize: 14, textAlign: 'center' }}>
+          {creator.name}
+        </Typography>
+        {handle && (
+          <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mt: 0.25 }}>
+            {platformIcon && <Iconify icon={platformIcon} width={14} color="text.secondary" />}
+            <Typography sx={{ fontSize: 12, color: 'text.secondary' }}>{handle}</Typography>
+          </Stack>
+        )}
+        {creator.interests?.length > 0 && (
+          <Stack direction="row" flexWrap="wrap" justifyContent="center" gap={0.5} sx={{ mt: 1.5 }}>
+            {creator.interests.slice(0, 3).map((interest) => (
+              <Chip
+                key={interest}
+                label={interest}
+                size="small"
+                variant="outlined"
+                sx={{
+                  fontSize: 8,
+                  fontWeight: 600,
+                  textTransform: 'uppercase',
+                  bgcolor: '#fff',
+                  borderColor: '#EBEBEB',
+                  color: '#8E8E93',
+                  boxShadow: '0px -2px 0px 0px #EBEBEB inset',
+                  borderRadius: '4px',
+                }}
+              />
+            ))}
+          </Stack>
+        )}
+      </Box>
+
+      {/* ─── Stats Row ───────────────────────────────────────────────────────── */}
+      <Stack
+        direction="row"
+        justifyContent="center"
+        flexWrap="wrap"
+        gap={3}
+        sx={{ mt: 3, width: '100%' }}
+      >
+        <StatItem label="Followers" value={formatNumber(followers)} />
+        <StatItem label="Engagement Rate" value={formatEngagementRate(engagementRate)} />
+        <StatItem label="Avg Likes" value={formatNumber(avgLikes)} />
+        {platform !== 'tiktok' && <StatItem label="Avg Saves" value={formatNumber(avgSaves)} />}
+        <StatItem label="Avg Shares" value={formatNumber(avgShares)} />
+      </Stack>
+
+      {/* ─── Bio ─────────────────────────────────────────────────────────────── */}
+      <Typography
+        sx={{
+          mt: 2,
+          fontSize: 13,
+          color: 'text.primary',
+          lineHeight: 1.6,
+          textAlign: 'center',
+          minHeight: 44,
+        }}
+      >
+        {bio || 'No bio available.'}
+      </Typography>
+
+      {/* ─── Top Content ─────────────────────────────────────────────────────── */}
+
+      <Typography sx={{ mt: 2.5, mb: 1, fontWeight: 700, fontSize: 14, alignSelf: 'flex-start' }}>
+        Top Content
+      </Typography>
+
+      <Stack direction="row" spacing={1} sx={{ width: '100%' }}>
+        {topVideos.length > 0 ? (
+          topVideos.map((video, idx) => (
+            <VideoThumbnail
+              key={video.id || video.video_id || idx}
+              video={video}
+              platform={platform}
+              tiktokHandle={creator.handles?.tiktok}
+            />
+          ))
+        ) : (
+          <Box
+            sx={{
+              width: '100%',
+              height: 180,
+              borderRadius: 1.5,
+              bgcolor: 'grey.100',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Typography sx={{ fontSize: 12, color: 'text.disabled' }}>No videos</Typography>
+          </Box>
+        )}
+      </Stack>
+    </Box>
+  );
+};
+
+CreatorColumn.propTypes = {
+  creator: PropTypes.object.isRequired,
+};
+
+// ─── Main Dialog ──────────────────────────────────────────────────────────────
+
+const CompareCreatorsDialog = ({ open, onClose, creators }) => {
+  const [left, right] = creators || [];
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      PaperProps={{
+        sx: {
+          borderRadius: 3,
+          p: { xs: 2, sm: 6 },
+          maxHeight: '90vh',
+					maxWidth: '80vw',
+          overflowY: 'auto',
+          // Hide scrollbar but allow scroll
+          scrollbarWidth: 'none', // Firefox
+          msOverflowStyle: 'none', // IE/Edge
+          '&::-webkit-scrollbar': {
+            display: 'none',
+          },
+        },
+      }}
+    >
+      {/* Close button */}
+      <IconButton onClick={onClose} sx={{ position: 'absolute', top: 12, right: 12, zIndex: 1 }}>
+        <Iconify icon="mdi:close" width={24} />
+      </IconButton>
+
+      {/* Side-by-side columns */}
+      <Stack
+        direction={{ xs: 'column', md: 'row' }}
+				spacing={{ xs: 2, sm: 6 }}
+        divider={
+          <Box
+            sx={{
+              display: 'block',
+              width: '1px',
+              alignSelf: 'stretch',
+              bgcolor: 'divider',
+            }}
+          />
+        }
+      >
+        {left && <CreatorColumn creator={left} />}
+        {right && <CreatorColumn creator={right} />}
+      </Stack>
+    </Dialog>
+  );
+};
+
+CompareCreatorsDialog.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  creators: PropTypes.arrayOf(PropTypes.object),
+};
+
+CompareCreatorsDialog.defaultProps = {
+  creators: [],
+};
+
+export default CompareCreatorsDialog;

--- a/src/sections/discovery-tool/view/discovery-tool-view.jsx
+++ b/src/sections/discovery-tool/view/discovery-tool-view.jsx
@@ -5,6 +5,7 @@ import { Box, Container, Pagination, Typography } from '@mui/material';
 import useGetDiscoveryCreators from 'src/hooks/use-get-discovery-creators';
 
 import { CreatorList, DiscoveryFilterBar } from '../components';
+import CompareCreatorsDialog from './compare-creators-dialog';
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
@@ -96,13 +97,27 @@ const DiscoveryToolView = () => {
 		setCurrentPage(nextPage);
 	}, []);
 
-	// Creator selection for comparison
+	// Creator selection & comparison
 	const [selectedCreatorIds, setSelectedCreatorIds] = useState([]);
+	const [compareOpen, setCompareOpen] = useState(false);
 
 	const handleSelectCreator = useCallback((rowId) => {
 		setSelectedCreatorIds((prev) =>
 			prev.includes(rowId) ? prev.filter((id) => id !== rowId) : [...prev, rowId]
 		);
+	}, []);
+
+	// Resolve selected creator objects for comparison dialog
+	const selectedCreators = useMemo(
+		() =>
+			selectedCreatorIds
+				.map((id) => creators.find((c) => (c.rowId || c.userId) === id))
+				.filter(Boolean),
+		[selectedCreatorIds, creators]
+	);
+
+	const handleCompare = useCallback(() => {
+		setCompareOpen(true);
 	}, []);
 
 	// Log results only when they actually change
@@ -133,35 +148,6 @@ const DiscoveryToolView = () => {
 			/>
 
 			{shouldShowResults && (
-				<Box
-					sx={{
-						mt: 3,
-						display: 'flex',
-						alignItems: 'center',
-						justifyContent: 'space-between',
-						gap: 2,
-						flexWrap: 'wrap',
-					}}
-				>
-					<Typography sx={{ fontSize: 14, color: 'text.secondary' }}>
-						{isLoading
-							? 'Loading creators…'
-							: `Showing ${viewedCount} of ${pagination?.total ?? creators.length} creator${(pagination?.total ?? creators.length) === 1 ? '' : 's'}`}
-					</Typography>
-
-					{!isLoading && totalPages > 1 && (
-						<Pagination
-							count={totalPages}
-							page={currentPage}
-							onChange={handlePageChange}
-							size="small"
-							variant='outlined'
-						/>
-					)}
-				</Box>
-			)}
-
-			{shouldShowResults && (
 				<CreatorList
 					creators={creators}
 					isLoading={isLoading}
@@ -169,8 +155,28 @@ const DiscoveryToolView = () => {
 					pagination={pagination}
 					selectedIds={selectedCreatorIds}
 					onSelect={handleSelectCreator}
+					onCompare={handleCompare}
 				/>
 			)}
+
+			{shouldShowResults && !isLoading && totalPages > 1 && (
+				<Box display={'flex'} justifyContent={'center'} mt={2}>
+					<Pagination
+						count={totalPages}
+						page={currentPage}
+						onChange={handlePageChange}
+						size="medium"
+						variant='contained'
+					/>
+				</Box>
+			)}
+
+			{/* Compare Dialog */}
+			<CompareCreatorsDialog
+				open={compareOpen}
+				onClose={() => setCompareOpen(false)}
+				creators={selectedCreators}
+			/>
 		</Container>
 	);
 };

--- a/src/sections/discovery-tool/view/discovery-tool-view.jsx
+++ b/src/sections/discovery-tool/view/discovery-tool-view.jsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { Container, Typography } from '@mui/material';
 
 import useGetDiscoveryCreators from 'src/hooks/use-get-discovery-creators';
+// import useGetMockDiscoveryCreators from 'src/hooks/use-get-mock-discovery-creators';
 
 import { DiscoveryFilterBar } from '../components';
 
@@ -12,6 +13,7 @@ const DiscoveryToolView = () => {
 	const [filters, setFilters] = useState({
 		platform: 'all',
 		debouncedKeyword: '',
+		debouncedHashtag: '',
 		ageRange: '',
 		country: null,
 		city: null,
@@ -30,6 +32,9 @@ const DiscoveryToolView = () => {
 		creditTier: filters.creditTier || undefined,
 		interests: filters.interests?.length ? filters.interests : undefined,
 		keyword: filters.debouncedKeyword || undefined,
+		hashtag: filters.debouncedHashtag || undefined,
+		page: 1,
+		limit: 50,
 	});
 
 	// Stable callback for the filter bar
@@ -39,7 +44,8 @@ const DiscoveryToolView = () => {
 
 	// Log results only when they actually change
 	useEffect(() => {
-		console.log(`Discovery creators (${creators.length}${pagination ? ` of ${pagination.total}` : ''}):`, creators);
+		console.log(`Discovery creators (${creators.length}${pagination ? ` of ${pagination.total}` : ''})`);
+		console.log('Creators array: ', creators)
 	}, [creators, pagination]);
 
 	return (

--- a/src/sections/discovery-tool/view/discovery-tool-view.jsx
+++ b/src/sections/discovery-tool/view/discovery-tool-view.jsx
@@ -1,8 +1,49 @@
-import { Container, Typography } from "@mui/material"
+import { useState, useEffect, useCallback } from 'react';
+
+import { Container, Typography } from '@mui/material';
+
+import useGetDiscoveryCreators from 'src/hooks/use-get-discovery-creators';
+
+import { DiscoveryFilterBar } from '../components';
+
+// ─── Component ────────────────────────────────────────────────────────────────
 
 const DiscoveryToolView = () => {
+	const [filters, setFilters] = useState({
+		platform: 'all',
+		debouncedKeyword: '',
+		ageRange: '',
+		country: null,
+		city: null,
+		gender: '',
+		creditTier: '',
+		interests: [],
+	});
+
+	// All filters are now server-side — pass them all to the SWR hook
+	const { creators, pagination, availableLocations, isLoading, isError } = useGetDiscoveryCreators({
+		platform: filters.platform,
+		gender: filters.gender || undefined,
+		ageRange: filters.ageRange || undefined,
+		country: filters.country || undefined,
+		city: filters.city || undefined,
+		creditTier: filters.creditTier || undefined,
+		interests: filters.interests?.length ? filters.interests : undefined,
+		keyword: filters.debouncedKeyword || undefined,
+	});
+
+	// Stable callback for the filter bar
+	const handleFiltersChange = useCallback((newFilters) => {
+		setFilters(newFilters);
+	}, []);
+
+	// Log results only when they actually change
+	useEffect(() => {
+		console.log(`Discovery creators (${creators.length}${pagination ? ` of ${pagination.total}` : ''}):`, creators);
+	}, [creators, pagination]);
+
 	return (
-		<Container>
+		<Container maxWidth="xl">
 			<Typography
 				sx={{
 					fontFamily: 'Aileron',
@@ -12,8 +53,25 @@ const DiscoveryToolView = () => {
 			>
 				Creator Discovery Tool
 			</Typography>
+
+			<DiscoveryFilterBar onFiltersChange={handleFiltersChange} availableLocations={availableLocations} />
+
+			{isLoading && <Typography sx={{ mt: 3 }}>Loading creators...</Typography>}
+			{isError && (
+				<Typography sx={{ mt: 3, color: 'error.main' }}>
+					Failed to fetch creators
+				</Typography>
+			)}
+
+			{!isLoading && !isError && (
+				<Typography sx={{ mt: 3, color: 'text.secondary' }}>
+					{creators.length} creator{creators.length !== 1 ? 's' : ''} found
+					{pagination ? ` (${pagination.total} total)` : ''}
+					{' — check console for detailed results'}
+				</Typography>
+			)}
 		</Container>
 	);
-}
+};
 
 export default DiscoveryToolView;

--- a/src/sections/discovery-tool/view/discovery-tool-view.jsx
+++ b/src/sections/discovery-tool/view/discovery-tool-view.jsx
@@ -4,8 +4,8 @@ import { Box, Container, Pagination, Typography } from '@mui/material';
 
 import useGetDiscoveryCreators from 'src/hooks/use-get-discovery-creators';
 
-import { CreatorList, DiscoveryFilterBar } from '../components';
 import CompareCreatorsDialog from './compare-creators-dialog';
+import { CreatorList, DiscoveryFilterBar } from '../components';
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
@@ -28,7 +28,7 @@ const DiscoveryToolView = () => {
 	const [currentPage, setCurrentPage] = useState(1);
 
 	// All filters are now server-side — pass them all to the SWR hook
-	const { creators, pagination, availableLocations, isLoading, isError, pageSize } = useGetDiscoveryCreators({
+	const { creators, pagination, availableLocations, isLoading, isError } = useGetDiscoveryCreators({
 		platform: filters.platform,
 		gender: filters.gender || undefined,
 		ageRange: filters.ageRange || undefined,
@@ -86,12 +86,6 @@ const DiscoveryToolView = () => {
 		if (!pagination?.total || !pagination?.limit) return 1;
 		return Math.max(1, Math.ceil(pagination.total / pagination.limit));
 	}, [pagination]);
-
-	const viewedCount = useMemo(() => {
-		const total = pagination?.total ?? creators.length;
-		if (!total) return 0;
-		return Math.min(currentPage * pageSize, total);
-	}, [pagination?.total, creators.length, currentPage, pageSize]);
 
 	const handlePageChange = useCallback((_event, nextPage) => {
 		setCurrentPage(nextPage);
@@ -160,7 +154,7 @@ const DiscoveryToolView = () => {
 			)}
 
 			{shouldShowResults && !isLoading && totalPages > 1 && (
-				<Box display={'flex'} justifyContent={'center'} mt={2}>
+				<Box display="flex" justifyContent="center" mt={2}>
 					<Pagination
 						count={totalPages}
 						page={currentPage}

--- a/src/sections/discovery-tool/view/discovery-tool-view.jsx
+++ b/src/sections/discovery-tool/view/discovery-tool-view.jsx
@@ -1,10 +1,10 @@
-import { useRef, useState, useMemo, useEffect, useCallback } from 'react';
+import { useRef, useMemo, useState, useEffect, useCallback } from 'react';
 
 import { Box, Container, Pagination, Typography } from '@mui/material';
 
 import useGetDiscoveryCreators from 'src/hooks/use-get-discovery-creators';
 
-import { DiscoveryFilterBar, CreatorList } from '../components';
+import { CreatorList, DiscoveryFilterBar } from '../components';
 
 // ─── Component ────────────────────────────────────────────────────────────────
 

--- a/src/sections/discovery-tool/view/discovery-tool-view.jsx
+++ b/src/sections/discovery-tool/view/discovery-tool-view.jsx
@@ -1,0 +1,19 @@
+import { Container, Typography } from "@mui/material"
+
+const DiscoveryToolView = () => {
+	return (
+		<Container>
+			<Typography
+				sx={{
+					fontFamily: 'Aileron',
+					fontSize: { xs: 24, md: 48 },
+					fontWeight: 400,
+				}}
+			>
+				Creator Discovery Tool
+			</Typography>
+		</Container>
+	);
+}
+
+export default DiscoveryToolView;

--- a/src/utils/axios.js
+++ b/src/utils/axios.js
@@ -349,6 +349,9 @@ export const endpoints = {
     stats: '/api/nps-feedback/stats',
     checkCreator: '/api/nps-feedback/check-creator',
   },
+  discovery: {
+    creators: '/api/discovery/creators',
+  },
   invoice: {
     getAll: '/api/invoice/',
     getCampaignById: (id) => `/api/campaign/getCampaignByIdInvoice/${id}`,

--- a/src/utils/socialMetricsCalculator.js
+++ b/src/utils/socialMetricsCalculator.js
@@ -5,9 +5,11 @@ export const getMetricValue = (insight, metricName) => {
 };
 
 export const formatNumber = (num) => {
-  if (num >= 1000000) return `${(num / 1000000).toFixed(1)  }M`;
-  if (num >= 1000) return `${(num / 1000).toFixed(1)  }K`;
-  return num.toLocaleString();
+  if (!num && num !== 0) return '0';
+  const rounded = Math.round(num);
+  if (rounded >= 1000000) return `${(rounded / 1000000).toFixed(1)  }M`;
+  if (rounded >= 1000) return `${(rounded / 1000).toFixed(1)  }K`;
+  return rounded.toLocaleString();
 };
 
 // Format number with commas for input fields (e.g., 2000 -> "2,000")


### PR DESCRIPTION
This pull request introduces a new "Creator Discovery Tool" feature to the dashboard, including the front-end route, navigation, and core UI components for filtering and displaying creators. It also includes minor UI improvements elsewhere and a bugfix for content sorting.

**Key changes:**

### Creator Discovery Tool Feature

* Added a new dashboard route and navigation entry for "Creator Discovery Tool", accessible to users with specific roles (`superadmin`, `CSM`, `CSL`, `client`, `god`). This includes updates to `paths.js`, navigation config, and route guards. [[1]](diffhunk://#diff-7318a8f6e629ca59d25778fc076b71bba7d957a9921c06b15b43431176fdefe7R33) [[2]](diffhunk://#diff-c591f6055b5a9e8c16580602e569ebacc0fd0212ad5c187795f33c176c972dafR169-R174) [[3]](diffhunk://#diff-0163df8eb4f6b2fc5e8552190c430aac0affe913357b7965ec15cd994decda6dL91-R93) [[4]](diffhunk://#diff-0163df8eb4f6b2fc5e8552190c430aac0affe913357b7965ec15cd994decda6dR239-R246)
* Implemented the main page component (`discovery-tool.jsx`) and view structure for the discovery tool.
* Added a custom React hook `useGetDiscoveryCreators` for fetching creators with filtering and pagination support.
* Developed core UI components:
  - [`DiscoveryFilterBar`](diffhunk://#diff-7a0ac7bc79ba3f175d70629d97ad5959adb5cde66ffd4db92d3a2a88f6af16b6R1-R395): a filter bar with debounced keyword/hashtag search, multi-select, and dynamic location options.
  - [`CreatorList`](diffhunk://#diff-418c26b03177f8e06cdc6c1cb442115c9bf20c74b0ee2a15e9b055d65184090bR1-R211): displays creators, supports loading/empty/error states, selection, and comparison.

### UI/UX Improvements

* Adjusted the positioning and z-index of a floating box in the dashboard main layout for better layering and spacing.

### Bugfixes

* Fixed a sorting bug in `TopContentGrid` to ensure top Instagram content is sorted in descending order by like count.