### PR TITLE
Fix: CCD-581 discovery tool invite modal

### DIFF
--- a/src/sections/campaign/manage-creator/campaign-item.jsx
+++ b/src/sections/campaign/manage-creator/campaign-item.jsx
@@ -13,6 +13,8 @@ import {
   CircularProgress,
 } from '@mui/material';
 
+import { useRouter } from 'src/routes/hooks';
+
 import { useBoolean } from 'src/hooks/use-boolean';
 
 import Image from 'src/components/image';
@@ -33,6 +35,7 @@ export default function CampaignItem({ campaign, user, autoOpen = false }) {
   // const { socket } = useSocketContext();
   // const router = useRouter();
   const theme = useTheme();
+  const router = useRouter();
 
   // const [bookMark, setBookMark] = useState(
   //   campaign?.bookMarkCampaign?.some((item) => item.userId === user?.id) || false
@@ -137,7 +140,17 @@ export default function CampaignItem({ campaign, user, autoOpen = false }) {
     if (autoOpen) {
       campaignInfo.onTrue();
     }
-  }, [autoOpen, campaignInfo]);
+  }, [campaignInfo, autoOpen]);
+
+  const handleModalClose = () => {
+    campaignInfo.onFalse();
+
+    const url = new URL(window.location.href);
+    if (url.searchParams.has('campaignId')) {
+      url.searchParams.delete('campaignId');
+      router.replace(`${url.pathname}${url.search}`);
+    }
+  };
 
   const handleCardClick = () => {
     campaignInfo.onTrue();
@@ -341,7 +354,7 @@ export default function CampaignItem({ campaign, user, autoOpen = false }) {
 
       <CampaignModal
         open={campaignInfo.value}
-        handleClose={campaignInfo.onFalse}
+        handleClose={handleModalClose}
         campaign={campaign}
       />
     </>

--- a/src/sections/campaign/manage-creator/campaign-modal.jsx
+++ b/src/sections/campaign/manage-creator/campaign-modal.jsx
@@ -205,14 +205,19 @@ const CampaignModal = ({ open, handleClose, campaign, mutate }) => {
     setJoinDialogOpen(true);
   };
 
+  const handleCloseAllModals = () => {
+    setJoinDialogOpen(false);
+    setFullImageOpen(false);
+    if (handleClose) handleClose();
+  };
+
   const handleJoinConfirm = async () => {
     if (!invitedCreator?.id) return;
     try {
       setIsJoining(true);
       await axiosInstance.patch(endpoints.campaign.pitch.v3.acceptInvite(invitedCreator.id));
       if (mutate) mutate();
-      handleClose();
-      setJoinDialogOpen(false);
+      handleCloseAllModals();
       handleManageClick(campaign.id);
     } catch (error) {
       console.error('Error joining campaign:', error);
@@ -222,8 +227,7 @@ const CampaignModal = ({ open, handleClose, campaign, mutate }) => {
   };
 
   const handleJoinDialogClose = () => {
-    setJoinDialogOpen(false);
-    handleClose();
+    handleCloseAllModals();
   };
 
   // const handleDraftClick = () => {
@@ -275,7 +279,7 @@ const CampaignModal = ({ open, handleClose, campaign, mutate }) => {
   };
 
   return (
-    <Dialog open={open} onClose={handleClose} fullWidth maxWidth="md" scroll="body">
+    <Dialog open={open} onClose={handleCloseAllModals} fullWidth maxWidth="md" scroll="body">
       <DialogContent sx={{ p: 0 }}>
         {/* Campaign image */}
         <Box
@@ -297,7 +301,7 @@ const CampaignModal = ({ open, handleClose, campaign, mutate }) => {
           onClick={handleImageClick}
         >
           <IconButton
-            onClick={handleClose}
+            onClick={handleCloseAllModals}
             sx={{
               position: 'absolute',
               top: 8,
@@ -1388,7 +1392,7 @@ const CampaignModal = ({ open, handleClose, campaign, mutate }) => {
       {/* Join Campaign Confirmation Dialog */}
       <Dialog
         open={joinDialogOpen}
-        onClose={() => setJoinDialogOpen(false)}
+        onClose={handleJoinDialogClose}
         maxWidth="xs"
         fullWidth
         PaperProps={{

--- a/src/sections/discovery-tool/view/invite-creators-dialog.jsx
+++ b/src/sections/discovery-tool/view/invite-creators-dialog.jsx
@@ -6,11 +6,11 @@ import {
   Stack,
   Button,
   Dialog,
-  Divider,
   Select,
+  Divider,
   MenuItem,
-  FormControl,
   Typography,
+  FormControl,
   DialogTitle,
   DialogContent,
   DialogActions,
@@ -101,14 +101,13 @@ const InviteCreatorsDialog = ({
                   }
                   sx={{
                     height: 28,
-                    borderColor: isAlreadyInCampaign ? 'error.main' : 'divider',
+                    borderColor: isAlreadyInCampaign ? '#D4321C' : 'divider',
                     bgcolor: 'background.paper',
                     boxShadow: '0px -2px 0px 0px #E7E7E7 inset',
-                    pb: 0.2,
                     pr: 0.5,
                     borderRadius: 0.8,
                     '& .MuiChip-deleteIcon': {
-                      color: isAlreadyInCampaign ? 'error.main' : undefined,
+                      color: isAlreadyInCampaign ? '#D4321C' : undefined,
                     },
                   }}
                 />
@@ -125,13 +124,16 @@ const InviteCreatorsDialog = ({
               sx={{
                 bgcolor: '#fff',
                 '& .MuiOutlinedInput-notchedOutline': {
-                  borderColor: hasSelectedCreatorsAlreadyInCampaign ? 'error.main' : undefined,
+                  borderColor: hasSelectedCreatorsAlreadyInCampaign ? '#D4321C' : undefined,
+                  borderWidth: 1
                 },
                 '&:hover .MuiOutlinedInput-notchedOutline': {
-                  borderColor: hasSelectedCreatorsAlreadyInCampaign ? 'error.main' : undefined,
+                  borderColor: hasSelectedCreatorsAlreadyInCampaign ? '#D4321C' : undefined,
+                  borderWidth: 1
                 },
                 '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-                  borderColor: hasSelectedCreatorsAlreadyInCampaign ? 'error.main' : undefined,
+                  borderColor: hasSelectedCreatorsAlreadyInCampaign ? '#D4321C' : undefined,
+                  borderWidth: 1,
                 },
               }}
               renderValue={(selected) => {
@@ -148,6 +150,7 @@ const InviteCreatorsDialog = ({
                 </MenuItem>
               ))}
             </Select>
+            {hasSelectedCreatorsAlreadyInCampaign && <Typography variant='caption' mt={0.5} color="#D4321C">Creator(s) Already in Campaign</Typography>}
           </FormControl>
         </Stack>
       </DialogContent>


### PR DESCRIPTION
This pull request focuses on improving the user experience and code maintainability for campaign management and creator invitation dialogs. The main changes include enhanced modal and dialog closing logic for campaigns, and improved error highlighting in the invite creators dialog.

**Campaign Modal and Campaign Item Improvements:**

- Added a new `handleModalClose` function in `campaign-item.jsx` to close the campaign modal and update the URL by removing the `campaignId` query parameter when the modal is closed. This ensures the URL stays in sync with the UI state. [[1]](diffhunk://#diff-8316968c37c737d9895d18c6a4179299eb9669a9025857cebf703e448914c78eL140-R153) [[2]](diffhunk://#diff-8316968c37c737d9895d18c6a4179299eb9669a9025857cebf703e448914c78eL344-R357)
- Updated the modal closing logic in `campaign-modal.jsx` so that closing actions (including dialog close, image close, and join confirmation) consistently close all related modals and dialogs using a new `handleCloseAllModals` function. This prevents modals from being left open unintentionally. [[1]](diffhunk://#diff-9b0999e8321da4f9731437e5aac99ddd1a84e0659f126bc69bad4fed23f66fb8R208-R220) [[2]](diffhunk://#diff-9b0999e8321da4f9731437e5aac99ddd1a84e0659f126bc69bad4fed23f66fb8L225-R230) [[3]](diffhunk://#diff-9b0999e8321da4f9731437e5aac99ddd1a84e0659f126bc69bad4fed23f66fb8L278-R282) [[4]](diffhunk://#diff-9b0999e8321da4f9731437e5aac99ddd1a84e0659f126bc69bad4fed23f66fb8L300-R304) [[5]](diffhunk://#diff-9b0999e8321da4f9731437e5aac99ddd1a84e0659f126bc69bad4fed23f66fb8L1391-R1395)
- Ensured that the router is properly imported and used in `campaign-item.jsx` for navigation and URL manipulation. [[1]](diffhunk://#diff-8316968c37c737d9895d18c6a4179299eb9669a9025857cebf703e448914c78eR16-R17) [[2]](diffhunk://#diff-8316968c37c737d9895d18c6a4179299eb9669a9025857cebf703e448914c78eR38)

**Invite Creators Dialog UI Enhancements:**

- Replaced the use of the theme's `'error.main'` color with a hardcoded red color (`#D4321C`) for error states in chips and input borders, ensuring consistent error color display regardless of theme changes. [[1]](diffhunk://#diff-daad66d4a074b458a9ecaffacfaa3606bfbf22081347505f1b4dcbe54258bae7L104-R110) [[2]](diffhunk://#diff-daad66d4a074b458a9ecaffacfaa3606bfbf22081347505f1b4dcbe54258bae7L128-R136)
- Added a caption below the select input to clearly indicate when selected creators are already in the campaign, improving user feedback.