### PR TITLE
fix: remove campaign check for CS scheduled v4 campaigns

### DIFF
--- a/src/sections/campaign/discover/admin/campaign-item.jsx
+++ b/src/sections/campaign/discover/admin/campaign-item.jsx
@@ -200,11 +200,6 @@ export default function CampaignItem({
     campaign?.status === 'PENDING_ADMIN_ACTIVATION' &&
     isUserAssignedToCampaign;
 
-  const isPendingReview =
-    campaign?.status === 'PENDING_CSM_REVIEW' ||
-    campaign?.status === 'SCHEDULED' ||
-    campaign?.status === 'PENDING_ADMIN_ACTIVATION';
-
   // Determine if the Activate Campaign button should be disabled
   const isDisabled =
     (isCSL || isSuperAdmin) &&
@@ -266,7 +261,6 @@ export default function CampaignItem({
                 <Typography sx={{ fontWeight: 800 }} variant="subtitle2">
                   {formatText(
                     campaign?.status === 'PENDING_CSM_REVIEW' ||
-                      campaign?.status === 'SCHEDULED' ||
                       campaign?.status === 'PENDING_ADMIN_ACTIVATION'
                       ? 'PENDING'
                       : campaign?.status
@@ -643,7 +637,7 @@ export default function CampaignItem({
             // Show button for superadmin/CSL to assign admin (initial activation)
             const showForInitialActivation =
               canInitialActivate &&
-              (campaign?.status === 'PENDING_CSM_REVIEW' || campaign?.status === 'SCHEDULED');
+              (campaign?.status === 'PENDING_CSM_REVIEW');
 
             // Show button for assigned admin/CSM to complete activation
             const showForCompleteActivation =
@@ -712,7 +706,7 @@ export default function CampaignItem({
                 // For superadmin on pending campaigns: use initial activation (admin assignment only)
                 if (
                   canInitialActivate &&
-                  (campaign?.status === 'PENDING_CSM_REVIEW' || campaign?.status === 'SCHEDULED')
+                  (campaign?.status === 'PENDING_CSM_REVIEW')
                 ) {
                   console.log('Opening InitialActivateDialog (admin assignment only)');
                   setInitialActivateDialogOpen(true);

--- a/src/sections/campaign/discover/admin/view/campaign-detail-view.jsx
+++ b/src/sections/campaign/discover/admin/view/campaign-detail-view.jsx
@@ -741,7 +741,6 @@ const CampaignDetailView = ({ id }) => {
 
   const isPendingCampaign = useMemo(
     () =>
-      campaign?.status === 'SCHEDULED' ||
       campaign?.status === 'PENDING_CSM_REVIEW' ||
       campaign?.status === 'PENDING_ADMIN_ACTIVATION',
     [campaign]
@@ -760,7 +759,7 @@ const CampaignDetailView = ({ id }) => {
               // For superadmin on pending campaigns: use initial activation (admin assignment only)
               if (
                 canInitialActivate &&
-                (campaign?.status === 'PENDING_CSM_REVIEW' || campaign?.status === 'SCHEDULED')
+                (campaign?.status === 'PENDING_CSM_REVIEW')
               ) {
                 console.log('Opening InitialActivateDialog (admin assignment only)');
                 setInitialActivateDialogOpen(true);

--- a/src/sections/campaign/manage/details/view/campaign-details-manage-view-v2.jsx
+++ b/src/sections/campaign/manage/details/view/campaign-details-manage-view-v2.jsx
@@ -286,6 +286,7 @@ const CampaignDetailManageViewV2 = ({ id }) => {
           <Chip
             label={campaign.status.replace(/_/g, ' ')}
             size="medium"
+            variant='outlined'
             sx={{
               fontWeight: 600,
               fontSize: '0.75rem',


### PR DESCRIPTION
This pull request refines the logic for handling campaign statuses in the admin campaign management components. The main focus is to consistently treat the `'SCHEDULED'` status separately from `'PENDING_CSM_REVIEW'` and `'PENDING_ADMIN_ACTIVATION'`, ensuring that certain actions and UI elements are only available for the intended statuses. Additionally, a minor UI improvement is made to the campaign status chip.

**Campaign status logic refinements:**

* The `'SCHEDULED'` status is no longer grouped with `'PENDING_CSM_REVIEW'` and `'PENDING_ADMIN_ACTIVATION'` in logic that determines pending campaigns, button visibility, and activation flows in both `campaign-item.jsx` and `campaign-detail-view.jsx`. This ensures that only campaigns in `'PENDING_CSM_REVIEW'` or `'PENDING_ADMIN_ACTIVATION'` are treated as pending for these purposes. [[1]](diffhunk://#diff-1c0af135f798964cf28293ac6b588800ac13525efd72573bd531c2da295191ffL203-L207) [[2]](diffhunk://#diff-1c0af135f798964cf28293ac6b588800ac13525efd72573bd531c2da295191ffL269) [[3]](diffhunk://#diff-1c0af135f798964cf28293ac6b588800ac13525efd72573bd531c2da295191ffL646-R640) [[4]](diffhunk://#diff-1c0af135f798964cf28293ac6b588800ac13525efd72573bd531c2da295191ffL715-R709) [[5]](diffhunk://#diff-ca423005c3dde26bbb53647123b5e04c80b131fbbbbcb2eedcffcf7e4dab4de8L744) [[6]](diffhunk://#diff-ca423005c3dde26bbb53647123b5e04c80b131fbbbbcb2eedcffcf7e4dab4de8L763-R762)

**UI improvements:**

* The campaign status `Chip` in `campaign-details-manage-view-v2.jsx` now uses the `'outlined'` variant for improved visual clarity.