### PR TITLE
Fix: CCD-581 reorganize imports and improve search button label logic

### DIFF
--- a/src/sections/discovery-tool/view/discovery-tool-npc-view.jsx
+++ b/src/sections/discovery-tool/view/discovery-tool-npc-view.jsx
@@ -1,29 +1,28 @@
+import PropTypes from 'prop-types';
 import { useMemo, useState } from 'react';
 
 import {
-  Avatar,
   Box,
-  Button,
   Card,
-  CardContent,
   Chip,
-  CircularProgress,
+  Link,
+  Stack,
+  Avatar,
+  Button,
+  Select,
+  MenuItem,
   Container,
   InputBase,
-  Link,
-  MenuItem,
   Pagination,
-  Select,
-  Stack,
   Typography,
+  CircularProgress,
 } from '@mui/material';
+
+import useGetDiscoveryNpcCreators from 'src/hooks/use-get-discovery-npc-creators';
 
 import { formatNumber } from 'src/utils/socialMetricsCalculator';
 
 import Iconify from 'src/components/iconify';
-
-import useGetDiscoveryNpcCreators from 'src/hooks/use-get-discovery-npc-creators';
-
 import EmptyContent from 'src/components/empty-content/empty-content';
 
 const formatFollowers = (value) => {
@@ -59,6 +58,10 @@ const EmptyProfileSvgIcon = ({ size = '100%' }) => (
     </g>
   </Box>
 );
+
+EmptyProfileSvgIcon.propTypes = {
+  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+};
 
 const DiscoveryToolNpcView = () => {
   const [filters, setFilters] = useState({
@@ -159,6 +162,13 @@ const DiscoveryToolNpcView = () => {
   const isDefaultDisabledState = !hasPendingFilterChanges && !hasAppliedFilters;
 
   const buttonDisabled = !hasPendingFilterChanges || isPreviewCountLoading;
+
+  let searchButtonLabel = `Show ${formatNumber(resultCount)} Creator${resultCount !== 1 ? 's' : ''}`;
+  if (isDefaultDisabledState) {
+    searchButtonLabel = 'Show Results';
+  } else if (isButtonLoading) {
+    searchButtonLabel = 'Searching creators...';
+  }
 
   const activePills = useMemo(() => {
     const pills = [];
@@ -329,11 +339,7 @@ const DiscoveryToolNpcView = () => {
             boxShadow: '0px -3px 0px 0px #00000073 inset',
           }}
         >
-          {isDefaultDisabledState
-            ? 'Show Results'
-            : isButtonLoading
-              ? 'Searching creators...'
-              : `Show ${formatNumber(resultCount)} Creator${resultCount !== 1 ? 's' : ''}`}
+          {searchButtonLabel}
         </Button>
       </Stack>
 


### PR DESCRIPTION
This pull request improves the `DiscoveryToolNpcView` component by refactoring how the search button label is determined and enhancing type safety for the `EmptyProfileSvgIcon` component. The most important changes are grouped below:

**UI/UX Improvements:**

* Refactored the logic for the search button label in `DiscoveryToolNpcView` by moving it into a dedicated variable (`searchButtonLabel`) for better readability and maintainability. The button now clearly reflects the current state (default, loading, or showing result count). [[1]](diffhunk://#diff-61bcfc5357c080e4d88b25c61b171ac439c96d8dbd7b77b18a940114efa80bf8R166-R172) [[2]](diffhunk://#diff-61bcfc5357c080e4d88b25c61b171ac439c96d8dbd7b77b18a940114efa80bf8L332-R342)

**Code Quality and Type Safety:**

* Added `propTypes` validation to `EmptyProfileSvgIcon`, ensuring the `size` prop is explicitly typed for improved reliability and maintainability.

**Imports Organization:**

* Reorganized and deduplicated imports in `discovery-tool-npc-view.jsx` for clarity and to prevent unnecessary import statements.