### PR TITLE
Fix: CCD-581 discovery tool NPC card layout

### DIFF
--- a/src/sections/discovery-tool/view/discovery-tool-npc-view.jsx
+++ b/src/sections/discovery-tool/view/discovery-tool-npc-view.jsx
@@ -3,7 +3,6 @@ import { useMemo, useState } from 'react';
 
 import {
   Box,
-  Card,
   Chip,
   Link,
   Stack,

--- a/src/sections/discovery-tool/view/discovery-tool-npc-view.jsx
+++ b/src/sections/discovery-tool/view/discovery-tool-npc-view.jsx
@@ -457,40 +457,42 @@ const DiscoveryToolNpcView = () => {
             }}
           >
             {sortedCreators.map((creator) => (
-              <Card
+              <Box
                 key={creator.rowId || creator.userId}
-                variant='elevation'
+                variant="elevation"
                 sx={{
                   borderRadius: 2,
                   p: 2,
-                  maxHeight: 200,
                   alignItems: 'center',
-                  justifyContent: 'center',
+                  justifyContent: 'space-between',
                   backgroundColor: '#efeff2',
                   display: 'flex',
                   flexDirection: 'column',
                   borderColor: '#d4d5db',
-                  boxShadow: '4px 4px 4px 0px #8D8D94'
+                  boxShadow: '4px 4px 4px 0px #8D8D94',
                 }}
               >
-
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flex: 1,
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                  }}
+                >
                   <Avatar
                     sx={{
                       width: 60,
                       height: 60,
                       padding: 0,
                       backgroundColor: '#D3D3D3',
-                      fontSize: 30,
-                      overflow: 'hidden',
-                      justifySelf: 'center',
                       mb: 1,
                     }}
                   >
                     <EmptyProfileSvgIcon size="100%" />
                   </Avatar>
 
-                  <Typography sx={{ fontSize: 12, fontWeight: 600}}>{creator.name}</Typography>
-
+                  <Typography sx={{ fontSize: 12, fontWeight: 600 }}>{creator.name}</Typography>
                   {/* Refactored to avoid nested ternary */}
                   {(() => {
                     if (creator.profileLink) {
@@ -503,7 +505,7 @@ const DiscoveryToolNpcView = () => {
                           sx={{
                             display: 'block',
                             textAlign: 'center',
-                            fontSize: 14,
+                            fontSize: 13.8,
                             textTransform: 'lowercase',
                             lineHeight: 1.35,
                             whiteSpace: 'normal',
@@ -519,17 +521,28 @@ const DiscoveryToolNpcView = () => {
                     }
                     return <Typography color="text.disabled">No profile link</Typography>;
                   })()}
+                </Box>
 
-                  <Box>
-                    <Typography sx={{ fontSize: 12, color: '#1340FF', fontWeight: 700, lineHeight: 1.6 }}>
-                      Followers
-                    </Typography>
-                    <Typography sx={{ lineHeight: 1, color: '#1340FF', fontFamily: 'Instrument Serif', fontSize: 32 }}>
-                      {formatFollowers(creator.followers)}
-                    </Typography>
-                  </Box>
-
-              </Card>
+                <Box sx={{ textAlign: 'center' }}>
+                  <Typography sx={{ fontSize: 12, color: '#1340FF', fontWeight: 700 }}>
+                    Followers
+                  </Typography>
+                  <Typography
+                    sx={{
+                      color: '#1340FF',
+                      fontFamily: 'Instrument Serif',
+                      fontSize: 32,
+                      lineHeight: 1,
+                      display: 'block',
+                      margin: 0,
+                      padding: 0,
+                      mt: 0.5
+                    }}
+                  >
+                    {formatFollowers(creator.followers)}
+                  </Typography>
+                </Box>
+              </Box>
             ))}
           </Box>
         </Box>


### PR DESCRIPTION
This pull request refactors the layout and styling of the creator cards in the `DiscoveryToolNpcView` component to improve visual structure and consistency. The main changes involve replacing the `Card` component with `Box`, reorganizing the content for better alignment, and fine-tuning typography and spacing.

**Component and layout refactor:**

* Replaced the `Card` component with a `Box` for each creator, and restructured the internal layout to use nested `Box` components for clearer separation of avatar/info and follower count sections. This also adjusts alignment to use `justifyContent: 'space-between'` for improved spacing.
* Moved the follower count section into its own centered `Box` and enhanced the styling of the follower number for better visual emphasis and consistency.

**Styling adjustments:**

* Slightly decreased the font size of the profile link to improve text fit and appearance.
* Cleaned up and standardized the avatar and text styling for a more cohesive look. [[1]](diffhunk://#diff-61bcfc5357c080e4d88b25c61b171ac439c96d8dbd7b77b18a940114efa80bf8L460-L493) [[2]](diffhunk://#diff-61bcfc5357c080e4d88b25c61b171ac439c96d8dbd7b77b18a940114efa80bf8R524-R545)