### PR TITLE
fix: deactivate admin user

### DIFF
--- a/src/_mock/_user.js
+++ b/src/_mock/_user.js
@@ -6,11 +6,11 @@ import { _mock } from './_mock';
 
 export const USER_STATUS_OPTIONS = [
   { value: 'active', label: 'Active' },
+  { value: 'banned', label: 'Inactive' },
   { value: 'blacklisted', label: 'Blacklisted' },
   { value: 'pending', label: 'Pending' },
   { value: 'suspended', label: 'Suspended' },
   { value: 'spam', label: 'Spam' },
-  { value: 'banned', label: 'Banned' },
   { value: 'rejected', label: 'Rejected' },
 ];
 

--- a/src/sections/admin/user-quick-edit-form.jsx
+++ b/src/sections/admin/user-quick-edit-form.jsx
@@ -13,6 +13,7 @@ import LoadingButton from '@mui/lab/LoadingButton';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
+import Alert from '@mui/material/Alert';
 import { Tab, Tabs, Stack, Select, InputLabel, FormControl, InputAdornment } from '@mui/material';
 
 import useGetRoles from 'src/hooks/use-get-roles';
@@ -30,7 +31,7 @@ import { MODULE_ITEMS } from './view/user-list-view';
 
 const ADMIN_STATUS = [
   {
-    label: 'Banned',
+    label: 'Inactive',
     value: 'banned',
     color: 'error',
   },
@@ -95,7 +96,7 @@ function UserQuickEditForm({ currentUser, open, onClose }) {
 
   const onSubmit = handleSubmit(async (data) => {
     try {
-      editAdmin({ ...data, userId: currentUser?.id });
+      await editAdmin({ ...data, userId: currentUser?.id });
       // await new Promise((resolve) => setTimeout(resolve, 500));
       // mutate(endpoints.users.admins);
       reset();
@@ -124,6 +125,7 @@ function UserQuickEditForm({ currentUser, open, onClose }) {
   }, []);
 
   const countryValue = watch('country');
+  const statusValue = watch('status');
 
   return (
     <Dialog
@@ -181,6 +183,12 @@ function UserQuickEditForm({ currentUser, open, onClose }) {
                   </MenuItem>
                 ))}
               </RHFSelect>
+
+              {statusValue === 'banned' && (
+                <Alert severity="warning" sx={{ gridColumn: { xs: 'span 1', sm: 'span 2' } }}>
+                  Setting this user to Inactive will remove them from all campaigns.
+                </Alert>
+              )}
 
               <RHFTextField name="name" label="Full Name" />
               <RHFTextField name="email" label="Email Address" />

--- a/src/sections/admin/user-table-row.jsx
+++ b/src/sections/admin/user-table-row.jsx
@@ -111,7 +111,7 @@ export default function UserTableRow({ row, selected, onEditRow, onSelectRow, on
               'default'
             }
           >
-            {status}
+            {status === 'banned' ? 'Inactive' : status}
           </Label>
         </TableCell>
 

--- a/src/sections/campaign/discover/admin/campaign-detail-content-client.jsx
+++ b/src/sections/campaign/discover/admin/campaign-detail-content-client.jsx
@@ -810,7 +810,7 @@ const CampaignDetailContentClient = ({ campaign }) => {
                   {additionalDetails?.creatorCompensation && (
                     <Box>
                       <Typography sx={SectionTitleStyle}>Creator Compensation</Typography>
-                      <Typography sx={SectionBodyStyle}>
+                      <Typography sx={{ ...SectionBodyStyle, whiteSpace: 'pre-line' }}>
                         {additionalDetails.creatorCompensation}
                       </Typography>
                     </Box>
@@ -819,7 +819,7 @@ const CampaignDetailContentClient = ({ campaign }) => {
                   {additionalDetails?.ctaDesiredAction && (
                     <Box>
                       <Typography sx={SectionTitleStyle}>Desired Action</Typography>
-                      <Typography sx={SectionBodyStyle}>
+                      <Typography sx={{ ...SectionBodyStyle, whiteSpace: 'pre-line' }}>
                         {additionalDetails.ctaDesiredAction}
                       </Typography>
                     </Box>
@@ -861,7 +861,7 @@ const CampaignDetailContentClient = ({ campaign }) => {
                   {additionalDetails?.ctaLinkInBioRequirements && (
                     <Box>
                       <Typography sx={SectionTitleStyle}>Link in Bio Requirements</Typography>
-                      <Typography sx={SectionBodyStyle}>
+                      <Typography sx={{ ...SectionBodyStyle, whiteSpace: 'pre-line' }}>
                         {additionalDetails.ctaLinkInBioRequirements}
                       </Typography>
                     </Box>
@@ -870,7 +870,7 @@ const CampaignDetailContentClient = ({ campaign }) => {
                   {additionalDetails?.specialNotesInstructions && (
                     <Box>
                       <Typography sx={SectionTitleStyle}>Special Notes/Instructions</Typography>
-                      <Typography sx={SectionBodyStyle}>
+                      <Typography sx={{ ...SectionBodyStyle, whiteSpace: 'pre-line' }}>
                         {additionalDetails.specialNotesInstructions}
                       </Typography>
                     </Box>

--- a/src/sections/campaign/manage/details/UpdateAdditionalOne.jsx
+++ b/src/sections/campaign/manage/details/UpdateAdditionalOne.jsx
@@ -232,7 +232,7 @@ const UpdateAdditionalOne = ({ campaign, campaignMutate }) => {
 
             {/* Main Message/Theme */}
             <FormField label="Main Message/Theme - What's the core message?">
-              <RHFTextField name="mainMessage" placeholder="Core Message" />
+              <RHFTextField name="mainMessage" placeholder="Core Message" multiline />
             </FormField>
 
             {/* Key Points to Cover */}
@@ -295,6 +295,7 @@ const UpdateAdditionalOne = ({ campaign, campaignMutate }) => {
               <RHFTextField
                 name="referenceContent"
                 placeholder="references.com"
+                multiline
                 size="small"
                 sx={{ '& .MuiOutlinedInput-root': { height: '50px' } }}
               />

--- a/src/sections/campaign/manage/details/UpdateAdditionalTwo.jsx
+++ b/src/sections/campaign/manage/details/UpdateAdditionalTwo.jsx
@@ -148,7 +148,7 @@ const UpdateAdditionalTwo = ({ campaign, campaignMutate }) => {
 
             {/* Creator Compensation - Value to Creator */}
             <FormField label="Creator Compensation - Value to Creator">
-              <RHFTextField name="creatorCompensation" placeholder="Creator Compensation" />
+              <RHFTextField name="creatorCompensation" placeholder="Creator Compensation" multiline />
             </FormField>
 
             {/* Call to Action - Desired Action */}
@@ -156,7 +156,7 @@ const UpdateAdditionalTwo = ({ campaign, campaignMutate }) => {
               <Typography variant="caption" color="#8E8E93" sx={{ mt: -0.5, mb: 0.5 }}>
                 [E.g., &quot;Visit website,&quot; &quot;Use promo code,&quot; &quot;Sign up&quot;]
               </Typography>
-              <RHFTextField name="ctaDesiredAction" placeholder="Desired Action" />
+              <RHFTextField name="ctaDesiredAction" placeholder="Desired Action" multiline />
             </FormField>
 
             {/* Call to Action - Link/URL */}
@@ -177,6 +177,7 @@ const UpdateAdditionalTwo = ({ campaign, campaignMutate }) => {
               <RHFTextField
                 name="ctaLinkInBioRequirements"
                 placeholder="Link in Bio Requirements"
+                multiline
               />
             </FormField>
 
@@ -185,6 +186,7 @@ const UpdateAdditionalTwo = ({ campaign, campaignMutate }) => {
               <RHFTextField
                 name="specialNotesInstructions"
                 placeholder="Special Notes/Instructions"
+                multiline
               />
             </FormField>
 

--- a/src/sections/client/campaign-create/additional-details-1.jsx
+++ b/src/sections/client/campaign-create/additional-details-1.jsx
@@ -96,6 +96,7 @@ export default function AdditionalDetails1() {
             <RHFTextField
               name="mainMessage"
               placeholder="Core Message"
+              multiline
             />
           </FormField>
 
@@ -159,6 +160,7 @@ export default function AdditionalDetails1() {
             <RHFTextField
               name="referenceContent"
               placeholder="references.com"
+              multiline
               size="small"
               sx={{ '& .MuiOutlinedInput-root': { height: '50px' } }}
             />

--- a/src/sections/client/campaign-create/additional-details-2.jsx
+++ b/src/sections/client/campaign-create/additional-details-2.jsx
@@ -77,6 +77,7 @@ export default function AdditionalDetails2() {
             <RHFTextField
               name="creatorCompensation"
               placeholder="Creator Compensation"
+              multiline
             />
           </FormField>
 
@@ -86,6 +87,7 @@ export default function AdditionalDetails2() {
             <RHFTextField
               name="ctaDesiredAction"
               placeholder="Desired Action"
+              multiline
             />
           </FormField>
 
@@ -114,6 +116,7 @@ export default function AdditionalDetails2() {
             <RHFTextField
               name="ctaLinkInBioRequirements"
               placeholder="Link in Bio Requirements"
+              multiline
             />
           </FormField>
 
@@ -122,6 +125,7 @@ export default function AdditionalDetails2() {
             <RHFTextField
               name="specialNotesInstructions"
               placeholder="Special Notes/Instructions"
+              multiline
             />
           </FormField>
 


### PR DESCRIPTION
This pull request introduces two main groups of changes: improvements to user status handling in the admin UI and enhancements to campaign form fields for better multi-line text support and display formatting.

**User Status Handling Improvements:**

* The label for the `banned` user status has been changed from "Banned" to "Inactive" throughout the admin UI, including dropdowns, status options, and status display in tables. This ensures consistency and clarity for admins managing user accounts. [[1]](diffhunk://#diff-630b96c15f273d8d88be03ac71770ee0aa4e4676cb3088be2938569aaa8e9aa4R9-L13) [[2]](diffhunk://#diff-538146ba476395c033fd154fd688d12f1809cd680e0e51ef279ecbc78f6000c1L33-R34) [[3]](diffhunk://#diff-bdacc9c085dbc5bcaaac4f6e544949abc4f4bc809354f0035288f82ea779b6ceL114-R114)
* An informational warning alert is now shown in the quick edit form when setting a user's status to "Inactive" (`banned`), explaining that this will remove them from all campaigns.
* The quick edit form now properly awaits the completion of the `editAdmin` async operation before resetting the form.
* The quick edit form tracks the selected status value to conditionally display the warning alert.
* Added the `Alert` component import to support the new warning message.

**Campaign Form Field Enhancements:**

* Several campaign-related form fields now support multi-line input by adding the `multiline` prop to `RHFTextField` components. This affects fields such as "Main Message/Theme," "Creator Compensation," "Desired Action," "Link in Bio Requirements," "Special Notes/Instructions," and "Reference Content" in both campaign creation and management flows. [[1]](diffhunk://#diff-cc58e64b28ecda9f313b4d62ac65ec0608776324ec4fcb802dde959920a48419L235-R235) [[2]](diffhunk://#diff-cc58e64b28ecda9f313b4d62ac65ec0608776324ec4fcb802dde959920a48419R298) [[3]](diffhunk://#diff-38b185087cea63b2cc73c625654cec764338be2a6e21bdd1fff93c001b31bb80L151-R159) [[4]](diffhunk://#diff-38b185087cea63b2cc73c625654cec764338be2a6e21bdd1fff93c001b31bb80R180) [[5]](diffhunk://#diff-38b185087cea63b2cc73c625654cec764338be2a6e21bdd1fff93c001b31bb80R189) [[6]](diffhunk://#diff-c6ce86cfc6ee41fc3d19692d034cd197ce1ba9a2b019afeaefaf7fdd3fbef291R99) [[7]](diffhunk://#diff-c6ce86cfc6ee41fc3d19692d034cd197ce1ba9a2b019afeaefaf7fdd3fbef291R163) [[8]](diffhunk://#diff-8030e6831c1f29179d54f2a6fcd249a8a692e9fe24e0033c4d0c4658778672f3R80) [[9]](diffhunk://#diff-8030e6831c1f29179d54f2a6fcd249a8a692e9fe24e0033c4d0c4658778672f3R90) [[10]](diffhunk://#diff-8030e6831c1f29179d54f2a6fcd249a8a692e9fe24e0033c4d0c4658778672f3R119) [[11]](diffhunk://#diff-8030e6831c1f29179d54f2a6fcd249a8a692e9fe24e0033c4d0c4658778672f3R128)
* Campaign detail sections that display these fields now use `whiteSpace: 'pre-line'` in their `Typography` components, ensuring that line breaks entered by users are rendered correctly in the UI. [[1]](diffhunk://#diff-ab23f91690d6023edfa5bec1dd9156867bec26e76bd2b321c165fb6ff77995c1L813-R813) [[2]](diffhunk://#diff-ab23f91690d6023edfa5bec1dd9156867bec26e76bd2b321c165fb6ff77995c1L822-R822) [[3]](diffhunk://#diff-ab23f91690d6023edfa5bec1dd9156867bec26e76bd2b321c165fb6ff77995c1L864-R864) [[4]](diffhunk://#diff-ab23f91690d6023edfa5bec1dd9156867bec26e76bd2b321c165fb6ff77995c1L873-R873)