### PR TITLE
feat: admin direct approve UI for video submissions with posting link

### DIFF
--- a/src/sections/campaign/discover/admin/campaign-analytics.jsx
+++ b/src/sections/campaign/discover/admin/campaign-analytics.jsx
@@ -14,9 +14,11 @@ import {
   Button,
   Dialog,
   Divider,
+  Tooltip,
   Skeleton,
   TextField,
   Typography,
+  IconButton,
   CircularProgress,
 } from '@mui/material';
 
@@ -43,6 +45,7 @@ import Iconify from 'src/components/iconify';
 import { useSnackbar } from 'src/components/snackbar';
 import { TopCreatorsLineChart, EngagementRateHeatmap } from 'src/components/trend-analysis';
 import {
+  MetricsSkeleton,
   ScrollingName,
   AnimatedNumber,
   PlatformOverviewMobile,

--- a/src/sections/campaign/discover/admin/campaign-creator-submissions-v4.jsx
+++ b/src/sections/campaign/discover/admin/campaign-creator-submissions-v4.jsx
@@ -200,6 +200,7 @@ function CreatorAccordion({ creator, campaign, isDisabled = false }) {
       // Admin-specific
       if (!isClient) {
         switch (status) {
+          case 'APPROVED':
           case 'CLIENT_APPROVED':
             // Only show PENDING_REVIEW color for video and photo submissions in normal campaigns
             if (
@@ -236,8 +237,9 @@ function CreatorAccordion({ creator, campaign, isDisabled = false }) {
         switch (status) {
           case 'IN_PROGRESS':
             return 'PROCESSING';
+          case 'APPROVED':
           case 'CLIENT_APPROVED':
-            // Only show PENDING POSTING for video and photo submissions, not raw footage
+            // Only show PENDING LINK for video and photo submissions, not raw footage
             if (submissionType === 'video' || submissionType === 'photo') {
               return 'PENDING LINK';
             }

--- a/src/sections/campaign/discover/admin/submissions/v4/mobile/mobile-creator-submissions.jsx
+++ b/src/sections/campaign/discover/admin/submissions/v4/mobile/mobile-creator-submissions.jsx
@@ -35,6 +35,7 @@ function MobileSubmissionRow({
     // Admin-specific
     if (!isClient) {
       switch (submissionStatus) {
+        case 'APPROVED':
         case 'CLIENT_APPROVED':
           if (campaignType === 'normal' && (submissionType === 'video' || submissionType === 'photo')) {
             return getStatusColor('PENDING_REVIEW');
@@ -69,6 +70,7 @@ function MobileSubmissionRow({
       switch (submissionStatus) {
         case 'IN_PROGRESS':
           return 'PROCESSING';
+        case 'APPROVED':
         case 'CLIENT_APPROVED':
           if (submissionType === 'video' || submissionType === 'photo') {
             return 'PENDING LINK';

--- a/src/sections/campaign/discover/admin/submissions/v4/photo-submission.jsx
+++ b/src/sections/campaign/discover/admin/submissions/v4/photo-submission.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import { enqueueSnackbar } from 'notistack';
 import { useRef, useMemo, useState, useCallback } from 'react';
 
-import { Box, Card, Chip, Stack, TextField, Typography, CircularProgress } from '@mui/material';
+import { Box, Button, Card, Chip, Stack, TextField, Typography, CircularProgress } from '@mui/material';
 
 import { approveV4Submission } from 'src/hooks/use-get-v4-submissions';
 
@@ -367,6 +367,27 @@ export default function V4PhotoSubmission({ submission, campaign, onUpdate, isDi
                           }
                           return null;
                         })()}
+                        {!isClient &&
+                          ['PENDING_REVIEW', 'CLIENT_FEEDBACK', 'CHANGES_REQUIRED', 'SENT_TO_CLIENT', 'APPROVED'].includes(submission.status) &&
+                          !(hasPostingLink && campaign?.campaignType === 'normal') && (
+                          <Button
+                            size="small"
+                            variant="text"
+                            onClick={() => setShowFeedbackLogs(true)}
+                            sx={{
+                              fontSize: { xs: 11, sm: 12 },
+                              color: '#919191',
+                              p: 0,
+                              minWidth: 'auto',
+                              textTransform: 'none',
+                              alignSelf: 'flex-start',
+                              mt: 0.5,
+                              '&:hover': { backgroundColor: 'transparent' },
+                            }}
+                          >
+                            view logs
+                          </Button>
+                        )}
                       </Box>
 
                       <Box
@@ -378,7 +399,8 @@ export default function V4PhotoSubmission({ submission, campaign, onUpdate, isDi
                         }}
                       >
                         {!isClient &&
-                        (submission.status === 'CLIENT_APPROVED' ||
+                        (submission.status === 'APPROVED' ||
+                          submission.status === 'CLIENT_APPROVED' ||
                           submission.status === 'POSTED' ||
                           submission.status === 'REJECTED') &&
                         campaign?.campaignType === 'normal' ? (

--- a/src/sections/campaign/discover/admin/submissions/v4/raw-footage-submission.jsx
+++ b/src/sections/campaign/discover/admin/submissions/v4/raw-footage-submission.jsx
@@ -4,6 +4,7 @@ import { useRef, useMemo, useState, useCallback } from 'react';
 
 import {
   Box,
+  Button,
   Card,
   Chip,
   Stack,
@@ -477,6 +478,26 @@ export default function V4RawFootageSubmission({
                           }
                           return null;
                         })()}
+                        {!isClient &&
+                          ['PENDING_REVIEW', 'CLIENT_FEEDBACK', 'CHANGES_REQUIRED', 'SENT_TO_CLIENT', 'APPROVED'].includes(submission.status) && (
+                          <Button
+                            size="small"
+                            variant="text"
+                            onClick={() => setShowFeedbackLogs(true)}
+                            sx={{
+                              fontSize: { xs: 11, sm: 12 },
+                              color: '#919191',
+                              p: 0,
+                              minWidth: 'auto',
+                              textTransform: 'none',
+                              alignSelf: 'flex-start',
+                              mt: 0.5,
+                              '&:hover': { backgroundColor: 'transparent' },
+                            }}
+                          >
+                            view logs
+                          </Button>
+                        )}
                       </Box>
 
                       <Box

--- a/src/sections/campaign/discover/admin/submissions/v4/shared/feedback-actions.jsx
+++ b/src/sections/campaign/discover/admin/submissions/v4/shared/feedback-actions.jsx
@@ -45,7 +45,7 @@ export default function FeedbackActions({
   const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
   const [reviewModalOpen, setReviewModalOpen] = useState(false);
   if (
-    (submission.status === 'CLIENT_APPROVED' || submission.status === 'POSTED' || hasPostingLink) &&
+    (submission.status === 'APPROVED' || submission.status === 'CLIENT_APPROVED' || submission.status === 'POSTED' || hasPostingLink) &&
     campaign?.campaignType === 'normal'
   ) {
     return null;
@@ -66,12 +66,17 @@ export default function FeedbackActions({
     handleApprove();
   };
 
-  const actionText = !isClient ? 'Send this Submission to Client?' : 'Approve Submission?';
+  const isVideoSubmission = submission.submissionType?.type === 'VIDEO';
+  const actionText = !isClient
+    ? (isVideoSubmission ? 'Approve Submission?' : 'Send this Submission to Client?')
+    : 'Approve Submission?';
 
   const modalIconSrc = !isClient
-    ? '/assets/images/modals/send_to_client.png'
+    ? (isVideoSubmission ? '/assets/images/modals/approve.png' : '/assets/images/modals/send_to_client.png')
     : '/assets/images/modals/approve.png';
-  const modalIconAlt = !isClient ? 'send_to_client' : 'approve';
+  const modalIconAlt = !isClient
+    ? (isVideoSubmission ? 'approve' : 'send_to_client')
+    : 'approve';
 
   return (
     <Box sx={{ flex: '0 0 auto' }}>
@@ -83,7 +88,7 @@ export default function FeedbackActions({
           justifyContent={{ xs: 'space-between', sm: 'flex-end' }}
           alignItems="center"
         >
-          {(visibility.showRequestChangeButton || submission.status === 'CHANGES_REQUIRED' || submission.status === 'SENT_TO_CLIENT' || submission.status === 'CLIENT_FEEDBACK') && (
+          {(visibility.showRequestChangeButton || submission.status === 'CHANGES_REQUIRED' || submission.status === 'SENT_TO_CLIENT' || submission.status === 'CLIENT_FEEDBACK' || submission.status === 'APPROVED') && (
             <Typography
               component="button"
               onClick={() => setReviewModalOpen(true)}
@@ -106,26 +111,6 @@ export default function FeedbackActions({
             >
               Review Submission
             </Typography>
-          )}
-
-          {!isClient && (
-            <Button
-              size="small"
-              variant="text"
-              onClick={onViewLogs}
-              sx={{
-                fontSize: { xs: 11, sm: 12 },
-                color: '#919191',
-                p: 0,
-                minWidth: 'auto',
-                textTransform: 'none',
-                '&:hover': {
-                  backgroundColor: 'transparent',
-                },
-              }}
-            >
-              view logs
-            </Button>
           )}
 
           {visibility.showChangeRequestForm && (
@@ -171,7 +156,7 @@ export default function FeedbackActions({
           )}
 
           {visibility.showApproveButton && (
-            <Tooltip title={!isClient ? 'Send to Client' : ''} arrow placement="top">
+            <Tooltip title={!isClient && !isVideoSubmission ? 'Send to Client' : ''} arrow placement="top">
               <Button
                 variant="contained"
                 color="success"

--- a/src/sections/campaign/discover/admin/submissions/v4/shared/feedback-actions.jsx
+++ b/src/sections/campaign/discover/admin/submissions/v4/shared/feedback-actions.jsx
@@ -67,16 +67,11 @@ export default function FeedbackActions({
   };
 
   const isVideoSubmission = submission.submissionType?.type === 'VIDEO';
-  const actionText = !isClient
-    ? (isVideoSubmission ? 'Approve Submission?' : 'Send this Submission to Client?')
-    : 'Approve Submission?';
+  const showApproveAction = isClient || isVideoSubmission;
 
-  const modalIconSrc = !isClient
-    ? (isVideoSubmission ? '/assets/images/modals/approve.png' : '/assets/images/modals/send_to_client.png')
-    : '/assets/images/modals/approve.png';
-  const modalIconAlt = !isClient
-    ? (isVideoSubmission ? 'approve' : 'send_to_client')
-    : 'approve';
+  const actionText = showApproveAction ? 'Approve Submission?' : 'Send this Submission to Client?';
+  const modalIconSrc = showApproveAction ? '/assets/images/modals/approve.png' : '/assets/images/modals/send_to_client.png';
+  const modalIconAlt = showApproveAction ? 'approve' : 'send_to_client';
 
   return (
     <Box sx={{ flex: '0 0 auto' }}>

--- a/src/sections/campaign/discover/admin/submissions/v4/shared/feedback-utils.js
+++ b/src/sections/campaign/discover/admin/submissions/v4/shared/feedback-utils.js
@@ -16,16 +16,16 @@ export function getFeedbackActionsVisibility({
   action
 }) {
   const showFeedbackActions =
-    (!isClient && (submission.status === 'PENDING_REVIEW' || submission.status === 'CLIENT_FEEDBACK' || submission.status === 'CHANGES_REQUIRED' || submission.status === 'SENT_TO_CLIENT')) ||
+    (!isClient && (submission.status === 'PENDING_REVIEW' || submission.status === 'CLIENT_FEEDBACK' || submission.status === 'CHANGES_REQUIRED' || submission.status === 'SENT_TO_CLIENT' || submission.status === 'APPROVED')) ||
     (isClient && submission.status === 'SENT_TO_CLIENT');
 
-  const isReadOnlyStatus = submission.status === 'CHANGES_REQUIRED' || submission.status === 'SENT_TO_CLIENT';
+  const isReadOnlyStatus = submission.status === 'CHANGES_REQUIRED' || submission.status === 'SENT_TO_CLIENT' || submission.status === 'APPROVED';
 
   const showRequestChangeButton = clientVisible && !isClientFeedback && action !== 'request_revision' && !isReadOnlyStatus;
 
   const showChangeRequestForm = action === 'request_revision' && clientVisible;
 
-  const showApproveButton = !isClientFeedback && action !== 'request_revision' && !isReadOnlyStatus;
+  const showApproveButton = action !== 'request_revision' && !isReadOnlyStatus;
 
   const showAdminClientFeedbackActions = false;
 

--- a/src/sections/campaign/discover/admin/submissions/v4/shared/posting-link-section.jsx
+++ b/src/sections/campaign/discover/admin/submissions/v4/shared/posting-link-section.jsx
@@ -25,7 +25,7 @@ import ConfirmDialogV2 from 'src/components/custom-dialog/confirm-dialog-v2';
 import { BUTTON_STYLES } from './submission-styles';
 import { posting_link_options_changes } from '../constants';
 
-export default function PostingLinkSection({ submission, onUpdate, onViewLogs, isDisabled = false }) {
+export default function PostingLinkSection({ submission, onUpdate, onViewLogs, onReviewSubmission, isDisabled = false }) {
   const { user } = useAuthContext();
   const [postingLink, setPostingLink] = useState(submission.content || '');
   const [loading, setLoading] = useState(false);
@@ -46,7 +46,7 @@ export default function PostingLinkSection({ submission, onUpdate, onViewLogs, i
       // eslint-disable-next-line no-new
       new URL(postingLink.trim());
     } catch {
-      enqueueSnackbar('Please entcer a valid URL', { variant: 'error' });
+      enqueueSnackbar('Please enter a valid URL', { variant: 'error' });
       return;
     }
 
@@ -119,9 +119,175 @@ export default function PostingLinkSection({ submission, onUpdate, onViewLogs, i
 
   const actionText = 'Approve Posting Link?';
 
+  const actionButtonSx = {
+    borderRadius: 1.15,
+    border: '1px solid #E7E7E7',
+    borderBottom: '3px solid #E7E7E7',
+    backgroundColor: '#FFFFFF',
+    boxShadow: 'none',
+    fontWeight: 800,
+    textTransform: 'none',
+    px: { xs: 1.8, sm: 2.25 },
+    py: { xs: 0.55, sm: 0.65 },
+    fontSize: { xs: '0.85rem', sm: '0.95rem' },
+    '&:hover': {
+      backgroundColor: '#F5F5F5',
+      boxShadow: 'none',
+    },
+  };
+
+  // Shared action buttons for approve/request-change (used by both creator-submitted and admin-submitted flows)
+  const renderActionButtons = () => (
+    <Stack spacing={1}>
+      <Stack direction="row" spacing={1} justifyContent="space-between">
+        {action === 'approve' && (
+          <Button
+            variant="contained"
+            color="warning"
+            onClick={() => setAction('request_revision')}
+            disabled={loading || isDisabled}
+            sx={{
+              ...actionButtonSx,
+              color: '#D4321C',
+            }}
+          >
+            {loading ? 'Processing...' : 'Request a Change'}
+          </Button>
+        )}
+        {action === 'request_revision' && (
+          <Box
+            display="flex"
+            flexDirection="row"
+            width="100%"
+            gap={1}
+            justifyContent="flex-end"
+          >
+            <Button
+              variant="contained"
+              color="secondary"
+              size="small"
+              onClick={() => {
+                setAction('approve');
+                setReasons([]);
+              }}
+              disabled={loading || isDisabled}
+              sx={{
+                ...BUTTON_STYLES.base,
+                ...BUTTON_STYLES.secondary,
+              }}
+            >
+              Cancel Change Request
+            </Button>
+            <Button
+              variant="contained"
+              color="warning"
+              size="small"
+              onClick={handleRejectPosting}
+              disabled={loading || isDisabled}
+              sx={{
+                ...BUTTON_STYLES.base,
+                ...BUTTON_STYLES.warning,
+              }}
+            >
+              {loading ? 'Processing...' : 'Send to Creator'}
+            </Button>
+          </Box>
+        )}
+        {action === 'approve' && (
+          <Button
+            variant="contained"
+            color="success"
+            onClick={() => setConfirmDialogOpen(true)}
+            disabled={loading || isDisabled}
+            sx={{
+              ...actionButtonSx,
+              color: '#1ABF66',
+            }}
+          >
+            {loading ? 'Processing...' : 'Approve'}
+          </Button>
+        )}
+      </Stack>
+      {action === 'request_revision' && (
+        <FormControl
+          fullWidth
+          style={{ backgroundColor: '#fff', borderRadius: 10 }}
+          hiddenLabel
+          size="small"
+        >
+          <Select
+            multiple
+            value={reasons}
+            onChange={(e) => setReasons(e.target.value)}
+            displayEmpty
+            renderValue={(selected) => {
+              if (selected.length === 0) {
+                return <span style={{ color: '#999' }}>Change Request Reasons</span>;
+              }
+              return (
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, maxHeight: 35 }}>
+                  {selected.map((value) => (
+                    <Chip key={value} label={value} size="small" />
+                  ))}
+                </Box>
+              );
+            }}
+          >
+            {posting_link_options_changes.map((option) => (
+              <MenuItem key={option} value={option}>
+                {option}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      )}
+    </Stack>
+  );
+
   return (
     <Box sx={{ flex: '0 0 auto' }}>
       <Box>
+        {/* Header row: "Posting Link" title + "Review Submission" button */}
+        {!isPosted && (
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              mb: 1,
+            }}
+          >
+            <Typography sx={{ fontWeight: 800, fontSize: 14, color: '#636366' }}>
+              Posting Link
+            </Typography>
+            {onReviewSubmission && (
+              <Typography
+                component="button"
+                onClick={onReviewSubmission}
+                sx={{
+                  pl: 2,
+                  pr: 0,
+                  py: 1,
+                  bgcolor: 'transparent',
+                  fontWeight: 800,
+                  fontSize: 14,
+                  color: '#919191',
+                  border: 'none',
+                  cursor: 'pointer',
+                  outline: 'none',
+                  transition: 'all 0.2s ease',
+                  '&:hover': {
+                    opacity: 0.8,
+                  },
+                }}
+              >
+                Review Submission
+              </Typography>
+            )}
+          </Box>
+        )}
+
         {isPosted && (
           <Box
             sx={{
@@ -198,257 +364,14 @@ export default function PostingLinkSection({ submission, onUpdate, onViewLogs, i
         )}
 
         {/* Posting link submitted by creator */}
-        {!postingLinkAddedByAdmin && !isPosted && submission.content && (
-          <Stack spacing={1}>
-            <Stack direction="row" spacing={1} justifyContent="flex-end">
-              {action === 'approve' && (
-                <Button
-                  variant="contained"
-                  color="warning"
-                  size="small"
-                  onClick={() => setAction('request_revision')}
-                  disabled={loading || isDisabled}
-                  sx={{
-                    ...BUTTON_STYLES.base,
-                    ...BUTTON_STYLES.warning,
-                  }}
-                >
-                  {loading ? 'Processing...' : 'Request a Change'}
-                </Button>
-              )}
-              {action === 'request_revision' && (
-                <Box
-                  display="flex"
-                  flexDirection="row"
-                  width="100%"
-                  gap={1}
-                  justifyContent="flex-end"
-                >
-                  <Button
-                    variant="contained"
-                    color="secondary"
-                    size="small"
-                    onClick={() => {
-                      setAction('approve');
-                      setReasons([]);
-                    }}
-                    disabled={loading || isDisabled}
-                    sx={{
-                      ...BUTTON_STYLES.base,
-                      ...BUTTON_STYLES.secondary,
-                    }}
-                  >
-                    Cancel Change Request
-                  </Button>
-                  <Button
-                    variant="contained"
-                    color="warning"
-                    size="small"
-                    onClick={handleRejectPosting}
-                    disabled={loading || isDisabled}
-                    sx={{
-                      ...BUTTON_STYLES.base,
-                      ...BUTTON_STYLES.warning,
-                    }}
-                  >
-                    {loading ? 'Processing...' : 'Send to Creator'}
-                  </Button>
-                </Box>
-              )}
-              {action === 'approve' && (
-                <Button
-                  variant="contained"
-                  color="success"
-                  size="small"
-                  onClick={() => setConfirmDialogOpen(true)}
-                  disabled={loading || isDisabled}
-                  sx={{
-                    ...BUTTON_STYLES.base,
-                    ...BUTTON_STYLES.success,
-                  }}
-                >
-                  {loading ? 'Processing...' : 'Approve'}
-                </Button>
-              )}
-            </Stack>
-            {action === 'request_revision' && (
-              <FormControl
-                fullWidth
-                style={{ backgroundColor: '#fff', borderRadius: 10 }}
-                hiddenLabel
-                size="small"
-              >
-                <Select
-                  multiple
-                  value={reasons}
-                  onChange={(e) => setReasons(e.target.value)}
-                  displayEmpty
-                  renderValue={(selected) => {
-                    if (selected.length === 0) {
-                      return <span style={{ color: '#999' }}>Change Request Reasons</span>;
-                    }
-                    return (
-                      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, maxHeight: 35 }}>
-                        {selected.map((value) => (
-                          <Chip key={value} label={value} size="small" />
-                        ))}
-                      </Box>
-                    );
-                  }}
-                >
-                  {posting_link_options_changes.map((option) => (
-                    <MenuItem key={option} value={option}>
-                      {option}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-            )}
-          </Stack>
-        )}
+        {!postingLinkAddedByAdmin && !isPosted && submission.content && renderActionButtons()}
 
         {/* Posting link to be approved by superadmin */}
-        {postingLinkAddedByAdmin && !isPosted && submission.content && isSuperAdmin && (
-          <Stack spacing={1}>
-            <Stack direction="row" spacing={1} justifyContent="flex-end">
-              {action === 'approve' && (
-                <Button
-                  variant="contained"
-                  color="warning"
-                  size="small"
-                  onClick={() => setAction('request_revision')}
-                  disabled={loading || isDisabled}
-                  sx={{
-                    ...BUTTON_STYLES.base,
-                    ...BUTTON_STYLES.warning,
-                  }}
-                >
-                  {loading ? 'Processing...' : 'Request a Change'}
-                </Button>
-              )}
-              {action === 'request_revision' && (
-                <Box
-                  display="flex"
-                  flexDirection="row"
-                  width="100%"
-                  gap={1}
-                  justifyContent="flex-end"
-                >
-                  <Button
-                    variant="contained"
-                    color="secondary"
-                    size="small"
-                    onClick={() => {
-                      setAction('approve');
-                      setReasons([]);
-                    }}
-                    disabled={loading || isDisabled}
-                    sx={{
-                      ...BUTTON_STYLES.base,
-                      ...BUTTON_STYLES.secondary,
-                    }}
-                  >
-                    Cancel Change Request
-                  </Button>
-                  <Button
-                    variant="contained"
-                    color="warning"
-                    size="small"
-                    onClick={handleRejectPosting}
-                    disabled={loading || isDisabled}
-                    sx={{
-                      ...BUTTON_STYLES.base,
-                      ...BUTTON_STYLES.warning,
-                    }}
-                  >
-                    {loading ? 'Processing...' : 'Send to Creator'}
-                  </Button>
-                </Box>
-              )}
-              {action === 'approve' && (
-                <Button
-                  variant="contained"
-                  color="success"
-                  size="small"
-                  onClick={() => setConfirmDialogOpen(true)}
-                  disabled={loading || isDisabled}
-                  sx={{
-                    ...BUTTON_STYLES.base,
-                    ...BUTTON_STYLES.success,
-                  }}
-                >
-                  {loading ? 'Processing...' : 'Approve'}
-                </Button>
-              )}
-            </Stack>
-            {action === 'request_revision' && (
-              <FormControl
-                fullWidth
-                style={{ backgroundColor: '#fff', borderRadius: 10 }}
-                hiddenLabel
-                size="small"
-              >
-                <Select
-                  multiple
-                  value={reasons}
-                  onChange={(e) => setReasons(e.target.value)}
-                  displayEmpty
-                  renderValue={(selected) => {
-                    if (selected.length === 0) {
-                      return <span style={{ color: '#999' }}>Change Request Reasons</span>;
-                    }
-                    return (
-                      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, maxHeight: 35 }}>
-                        {selected.map((value) => (
-                          <Chip key={value} label={value} size="small" />
-                        ))}
-                      </Box>
-                    );
-                  }}
-                >
-                  {posting_link_options_changes.map((option) => (
-                    <MenuItem key={option} value={option}>
-                      {option}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-            )}
-          </Stack>
-        )}
+        {postingLinkAddedByAdmin && !isPosted && submission.content && isSuperAdmin && renderActionButtons()}
 
-        {/* Posting link added by admin */}
+        {/* No posting link yet — admin can enter one */}
         {!submission.content && (
           <Box display="flex" flexDirection="column">
-            <Box
-              sx={{
-                display: 'flex',
-                flexDirection: 'row',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-              }}
-            >
-              <Typography variant="caption" fontWeight="bold" color="#636366">
-                Posting Link
-              </Typography>
-              <Button
-                size="small"
-                variant="text"
-                onClick={onViewLogs}
-                sx={{
-                  fontSize: 12,
-                  color: '#919191',
-                  p: 0,
-                  minWidth: 'auto',
-                  textTransform: 'none',
-                  '&:hover': {
-                    backgroundColor: 'transparent',
-                  },
-                }}
-              >
-                view logs
-              </Button>
-            </Box>
             <TextField
               fullWidth
               size="medium"
@@ -457,7 +380,6 @@ export default function PostingLinkSection({ submission, onUpdate, onViewLogs, i
               onChange={(e) => setPostingLink(e.target.value)}
               disabled={loading || isDisabled}
               sx={{
-                mt: 1,
                 mb: 2,
                 '& .MuiOutlinedInput-root': {
                   bgcolor: 'background.paper',
@@ -468,13 +390,11 @@ export default function PostingLinkSection({ submission, onUpdate, onViewLogs, i
               <Button
                 variant="contained"
                 color="success"
-                size="small"
                 onClick={handleSubmitPostingLink}
                 disabled={loading || isDisabled}
                 sx={{
-                  display: 'flex',
-                  ...BUTTON_STYLES.base,
-                  ...BUTTON_STYLES.success,
+                  ...actionButtonSx,
+                  color: '#1ABF66',
                 }}
               >
                 {loading ? 'Saving...' : 'Submit'}
@@ -519,5 +439,6 @@ PostingLinkSection.propTypes = {
   submission: PropTypes.object.isRequired,
   onUpdate: PropTypes.func,
   onViewLogs: PropTypes.any,
+  onReviewSubmission: PropTypes.func,
   isDisabled: PropTypes.bool,
 };

--- a/src/sections/campaign/discover/admin/submissions/v4/video-submission.jsx
+++ b/src/sections/campaign/discover/admin/submissions/v4/video-submission.jsx
@@ -134,7 +134,7 @@ export default function V4VideoSubmission({ submission, campaign, onUpdate, isDi
         setTimeout(() => setLocalActionInProgress(false), 300);
       }
     }
-  }, [feedback, reasons, caption, submission.id, onUpdate, isClient, localActionInProgress, showNpsModal]);
+  }, [feedback, reasons, caption, submission.id, video?.id, onUpdate, isClient, localActionInProgress, showNpsModal]);
 
   const handleRequestChanges = useCallback(async () => {
     const currentFeedback = feedback;
@@ -197,7 +197,7 @@ export default function V4VideoSubmission({ submission, campaign, onUpdate, isDi
         setTimeout(() => setLocalActionInProgress(false), 300);
       }
     }
-  }, [feedback, reasons, caption, submission.id, onUpdate, isClient, localActionInProgress, showNpsModal]);
+  }, [feedback, reasons, caption, submission.id, video?.id, onUpdate, isClient, localActionInProgress, showNpsModal]);
 
   const handleSendComments = useCallback(
     async (videoIdToPublish) => {
@@ -904,9 +904,9 @@ export default function V4VideoSubmission({ submission, campaign, onUpdate, isDi
         open={adminReviewModalOpen}
         onClose={() => setAdminReviewModalOpen(false)}
         submission={submission}
-        rightSideContent={({ currentTime, onSeek, videoId: modalVideoId, videoPage, setVideoPage, videoCount, isPastVideo, submission: modalSubmission }) => (
+        rightSideContent={({ currentTime: modalCurrentTime, onSeek, videoId: modalVideoId, videoPage, setVideoPage, videoCount, isPastVideo, submission: modalSubmission }) => (
           <AdminFeedbackPanel
-            currentTime={currentTime}
+            currentTime={modalCurrentTime}
             onSeek={onSeek}
             submission={modalSubmission || submission}
             videoId={modalVideoId || video?.id}

--- a/src/sections/campaign/discover/admin/submissions/v4/video-submission.jsx
+++ b/src/sections/campaign/discover/admin/submissions/v4/video-submission.jsx
@@ -7,6 +7,7 @@ import {
   Card,
   Chip,
   Stack,
+  Button,
   Slider,
   TextField,
   Typography,
@@ -489,14 +490,36 @@ export default function V4VideoSubmission({ submission, campaign, onUpdate, isDi
                           }
                           return null;
                         })()}
+                        {!isClient &&
+                          ['PENDING_REVIEW', 'CLIENT_FEEDBACK', 'CHANGES_REQUIRED', 'SENT_TO_CLIENT', 'APPROVED'].includes(submission.status) &&
+                          !(hasPostingLink && campaign?.campaignType === 'normal') && (
+                          <Button
+                            size="small"
+                            variant="text"
+                            onClick={() => setShowFeedbackLogs(true)}
+                            sx={{
+                              fontSize: { xs: 11, sm: 12 },
+                              color: '#919191',
+                              p: 0,
+                              minWidth: 'auto',
+                              textTransform: 'none',
+                              alignSelf: 'flex-start',
+                              mt: 0.5,
+                              '&:hover': { backgroundColor: 'transparent' },
+                            }}
+                          >
+                            view logs
+                          </Button>
+                        )}
                       </Box>
 
                       <Box sx={{ flex: 'auto 0 1', minHeight: 0, display: 'flex', flexDirection: 'column' }}>
-                        {!isClient && (submission.status === 'CLIENT_APPROVED' || submission.status === 'POSTED' || submission.status === 'REJECTED') && campaign?.campaignType === 'normal' ? (
+                        {!isClient && (submission.status === 'APPROVED' || submission.status === 'CLIENT_APPROVED' || submission.status === 'POSTED' || submission.status === 'REJECTED') && campaign?.campaignType === 'normal' ? (
                           <PostingLinkSection
                             submission={submission}
                             onUpdate={onUpdate}
                             onViewLogs={() => setShowFeedbackLogs(true)}
+                            onReviewSubmission={() => setAdminReviewModalOpen(true)}
                             isDisabled={isDisabled}
                           />
                         ) : (

--- a/src/sections/campaign/manage-creator/v4/submissions/VideoSubmissionModal.jsx
+++ b/src/sections/campaign/manage-creator/v4/submissions/VideoSubmissionModal.jsx
@@ -86,7 +86,7 @@ const VideoSubmissionModal = ({
     return () => {
       isMounted = false;
     };
-  }, [open, submission?.id]);
+  }, [open, submission]);
 
   if (!open || !submission) return null;
 
@@ -377,8 +377,9 @@ const VideoSubmissionModal = ({
             </Box>
 
             {/* Right Side - Flexible Content (Client/Creator/Admin specific) */}
-            {(typeof rightSideContent === 'function'
-              ? rightSideContent({
+            {(() => {
+              if (typeof rightSideContent === 'function') {
+                return rightSideContent({
                   videoPage,
                   setVideoPage,
                   videoCount,
@@ -392,23 +393,26 @@ const VideoSubmissionModal = ({
                   currentVideoTime: formatTime(modalCurrentTime),
                   onSeekTo: handleModalSeek,
                   ref: feedbackPanelRef,
-                })
-              : React.isValidElement(rightSideContent)
-                ? React.cloneElement(rightSideContent, {
-                    ref: feedbackPanelRef,
-                    submissionId: effectiveSubmission.id,
-                    videoId: currentVideo?.id,
-                    isLocked:
-                      !['SENT_TO_CLIENT'].includes(effectiveSubmission.status) ||
-                      videoPage !== 0,
-                    isPastVideo: videoPage !== 0,
-                    currentVideoTime: formatTime(modalCurrentTime),
-                    onSeekTo: handleModalSeek,
-                    videoPage,
-                    setVideoPage,
-                    videoCount,
-                  })
-                : rightSideContent) || (
+                });
+              }
+              if (React.isValidElement(rightSideContent)) {
+                return React.cloneElement(rightSideContent, {
+                  ref: feedbackPanelRef,
+                  submissionId: effectiveSubmission.id,
+                  videoId: currentVideo?.id,
+                  isLocked:
+                    !['SENT_TO_CLIENT'].includes(effectiveSubmission.status) ||
+                    videoPage !== 0,
+                  isPastVideo: videoPage !== 0,
+                  currentVideoTime: formatTime(modalCurrentTime),
+                  onSeekTo: handleModalSeek,
+                  videoPage,
+                  setVideoPage,
+                  videoCount,
+                });
+              }
+              return rightSideContent;
+            })() || (
               <Box
                 sx={{
                   flex: { xs: '1 1 auto', md: '0 0 calc(40% - 20px)' },
@@ -507,7 +511,7 @@ const VideoSubmissionModal = ({
               },
             }}
           >
-            Yes, I'm done with my feedback
+            Yes, I&apos;m done with my feedback
           </LoadingButton>
           <Button
             fullWidth
@@ -555,6 +559,9 @@ VideoSubmissionModal.propTypes = {
     creator: PropTypes.object,
     admin: PropTypes.object,
     creatorName: PropTypes.string,
+    campaign: PropTypes.shape({
+      name: PropTypes.string,
+    }),
   }),
   creator: PropTypes.shape({
     name: PropTypes.string,

--- a/src/sections/campaign/manage-creator/v4/submissions/admin-feedback-modal.jsx
+++ b/src/sections/campaign/manage-creator/v4/submissions/admin-feedback-modal.jsx
@@ -9,11 +9,8 @@ import ConfirmDialogV2 from 'src/components/custom-dialog/confirm-dialog-v2';
 import { useSubmissionComments } from 'src/hooks/use-submission-comments';
 
 import { fDateTime } from 'src/utils/format-time';
-import axiosInstance, { endpoints } from 'src/utils/axios';
 
 import useSocketContext from 'src/socket/hooks/useSocketContext';
-
-import Iconify from 'src/components/iconify';
 
 // ---------------------------------------------------------------------------
 // Utilities

--- a/src/sections/campaign/manage-creator/v4/submissions/admin-feedback-modal.jsx
+++ b/src/sections/campaign/manage-creator/v4/submissions/admin-feedback-modal.jsx
@@ -86,9 +86,8 @@ const CommentCard = ({
   // Display forwardedBy name if set, otherwise user name
   const displayName = comment.forwardedBy?.name || comment.user?.name || 'Unknown';
   const displayPhoto = comment.forwardedBy?.photoURL || comment.user?.photoURL || comment?.user?.client?.company?.logo || null;
-  const displayRole = comment.forwardedBy
-    ? 'Admin'
-    : comment.user?.role?.charAt(0).toUpperCase() + comment.user?.role?.slice(1) || '';
+  const role = comment.user?.role;
+  const displayRole = comment.forwardedBy ? 'Admin' : (role && role.charAt(0).toUpperCase() + role.slice(1)) || '';
 
   const isEditing = editTarget?.commentId === comment.id;
   const editFocusedRef = useRef(false);

--- a/src/sections/campaign/manage-creator/v4/submissions/admin-feedback-modal.jsx
+++ b/src/sections/campaign/manage-creator/v4/submissions/admin-feedback-modal.jsx
@@ -5,6 +5,7 @@ import React, { useRef, useState, useEffect } from 'react';
 
 import { Box, Avatar, Button, Tooltip, TextField, Typography, IconButton, CircularProgress } from '@mui/material';
 
+import ConfirmDialogV2 from 'src/components/custom-dialog/confirm-dialog-v2';
 import { useSubmissionComments } from 'src/hooks/use-submission-comments';
 
 import { fDateTime } from 'src/utils/format-time';
@@ -488,6 +489,7 @@ export default function AdminFeedbackPanel({
   const [editTarget, setEditTarget] = useState(null); // { commentId, originalText }
   const [editText, setEditText] = useState('');
   const [sending, setSending] = useState(false);
+  const [confirmSendToClientOpen, setConfirmSendToClientOpen] = useState(false);
 
   const { socket } = useSocketContext();
   const { comments, commentsLoading, commentsMutate } = useSubmissionComments(
@@ -650,7 +652,7 @@ export default function AdminFeedbackPanel({
   };
 
   // ---- Button visibility ----
-  const isReadOnly = isPastVideo || submission?.status === 'CHANGES_REQUIRED' || submission?.status === 'SENT_TO_CLIENT';
+  const isReadOnly = isPastVideo || submission?.status === 'CHANGES_REQUIRED' || submission?.status === 'SENT_TO_CLIENT' || submission?.status === 'APPROVED' || submission?.status === 'CLIENT_APPROVED';
 
   const showSendToClient =
     submission?.status === 'PENDING_REVIEW' && submission?.campaign?.origin !== 'ADMIN';
@@ -1008,7 +1010,7 @@ export default function AdminFeedbackPanel({
                 variant="contained"
                 disableElevation
                 disabled={!hasComments || sending}
-                onClick={handleSendToClient}
+                onClick={() => setConfirmSendToClientOpen(true)}
                 sx={{
                   fontWeight: 700,
                   fontSize: { xs: '0.8rem', md: '0.85rem', lg: '0.95rem' },
@@ -1043,6 +1045,33 @@ export default function AdminFeedbackPanel({
           </Box>
         )}
       </Box>
+
+      <ConfirmDialogV2
+        open={confirmSendToClientOpen}
+        onClose={() => setConfirmSendToClientOpen(false)}
+        title="Send this Submission to Client?"
+        emoji={
+          <Avatar
+            src="/assets/images/modals/send_to_client.png"
+            alt="send_to_client"
+            sx={{ width: 80, height: 80 }}
+          />
+        }
+        content=""
+        action={
+          <Button
+            variant="contained"
+            color="success"
+            onClick={() => {
+              setConfirmSendToClientOpen(false);
+              handleSendToClient();
+            }}
+            disabled={sending}
+          >
+            Send this Submission to Client?
+          </Button>
+        }
+      />
     </Box>
   );
 }

--- a/src/sections/campaign/manage-creator/v4/submissions/admin-feedback-modal.jsx
+++ b/src/sections/campaign/manage-creator/v4/submissions/admin-feedback-modal.jsx
@@ -4,8 +4,9 @@ import { m, AnimatePresence } from 'framer-motion';
 import React, { useRef, useState, useEffect } from 'react';
 
 import { Box, Avatar, Button, Tooltip, TextField, Typography, IconButton, CircularProgress } from '@mui/material';
-
+import Iconify from 'src/components/iconify';
 import ConfirmDialogV2 from 'src/components/custom-dialog/confirm-dialog-v2';
+import axiosInstance, { endpoints } from 'src/utils/axios';
 import { useSubmissionComments } from 'src/hooks/use-submission-comments';
 
 import { fDateTime } from 'src/utils/format-time';

--- a/src/sections/campaign/manage-creator/v4/submissions/client-feedback-modal.jsx
+++ b/src/sections/campaign/manage-creator/v4/submissions/client-feedback-modal.jsx
@@ -302,6 +302,16 @@ CommentCard.propTypes = {
       id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       name: PropTypes.string,
       role: PropTypes.string,
+      photoURL: PropTypes.string,
+      client: PropTypes.shape({
+        company: PropTypes.shape({
+          logo: PropTypes.string,
+        }),
+      }),
+    }),
+    forwardedBy: PropTypes.shape({
+      name: PropTypes.string,
+      photoURL: PropTypes.string,
     }),
     agreedBy: PropTypes.arrayOf(
       PropTypes.shape({

--- a/src/sections/campaign/manage-creator/v4/submissions/feeedback-component/CreatorFeedbackModal.jsx
+++ b/src/sections/campaign/manage-creator/v4/submissions/feeedback-component/CreatorFeedbackModal.jsx
@@ -290,6 +290,11 @@ ReplyItem.propTypes = {
     createdAt: PropTypes.string.isRequired,
     creatorName: PropTypes.string.isRequired,
     creatorPhoto: PropTypes.string,
+    user: PropTypes.shape({
+      name: PropTypes.string,
+      role: PropTypes.string,
+      photoURL: PropTypes.string,
+    }),
   }).isRequired,
 };
 

--- a/src/sections/campaign/manage-creator/v4/submissions/shared/submissionHelpers.js
+++ b/src/sections/campaign/manage-creator/v4/submissions/shared/submissionHelpers.js
@@ -93,7 +93,7 @@ export const getButtonStates = ({
     postingLoading ||
     status === 'PENDING_REVIEW' ||
     status === 'POSTED' ||
-    status === 'APPROVED' || // Added - prevent submission when already approved
+    (status === 'APPROVED' && !isPostingLinkEditable) || // prevent submission when approved, but allow posting link
     (status !== 'CHANGES_REQUIRED' &&
       status !== 'NOT_STARTED' &&
       status !== 'CLIENT_APPROVED' &&


### PR DESCRIPTION
## Summary
- Admin can now directly approve video submissions on v4 campaigns (no need for client to approve anymore)
- "Send to Client" flow moved to "Send Feedback to Client" button inside Review Submission modal with confirmation dialog
- Approve button now available in CLIENT_FEEDBACK status
- Review Submission modal is read-only for APPROVED and CLIENT_APPROVED statuses