### PR TITLE
fix: user performance card number display

### DIFF
--- a/src/utils/socialMetricsCalculator.js
+++ b/src/utils/socialMetricsCalculator.js
@@ -12,8 +12,6 @@ export const formatNumber = (num) => {
     // Show no decimal if exact million
     return value % 1 === 0 ? `${value}M` : `${value.toFixed(1)}M`;
   }
-  if (rounded >= 100000) return `${(rounded / 100000).toFixed(1)  }K`;
-  if (rounded >= 10000) return `${(rounded / 10000).toFixed(1)  }K`;
   if (rounded >= 1000) {
     const value = rounded / 1000;
     // Show no decimal if exact thousand


### PR DESCRIPTION
This pull request makes a minor update to the `formatNumber` function in `src/utils/socialMetricsCalculator.js` to simplify how large numbers are formatted.

Number formatting simplification:

* Removed the logic for formatting numbers in the ten-thousands and hundred-thousands range with a 'K' suffix, so now only numbers in the thousands are formatted with 'K'.